### PR TITLE
Fix concurrency issue in the weekly build trigger

### DIFF
--- a/jenkins_jobs/trigger_weekly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_weekly_host_os_build.groovy
@@ -15,9 +15,6 @@ job('trigger_weekly_host_os_build') {
     stringParam('UPLOAD_SERVER_USER_NAME',
 		"${UPLOAD_SERVER_USER_NAME}",
 		'User name of the target server to upload build results.')
-    stringParam('UPLOAD_SERVER_BUILDS_DIR',
-		"${UPLOAD_SERVER_BUILDS_DIR}",
-		'Directory in the target server to upload build results.')
     stringParam('UPLOAD_SERVER_WEEKLY_DIR',
 		"${UPLOAD_SERVER_WEEKLY_DIR}",
 		'Directory in the target server to upload weekly build results.')

--- a/jenkins_jobs/trigger_weekly_host_os_build/post_build_script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/post_build_script.sh
@@ -1,6 +1,5 @@
 WEEKLY_DIR_NAME=$(cat WEEKLY_DIR_NAME)
-BUILD_DIR_NAME=$(rsync -e "ssh -i $HOME/.ssh/${UPLOAD_SERVER_USER_NAME}_id_rsa" --list-only "${UPLOAD_SERVER_USER_NAME}@${UPLOAD_SERVER_HOST_NAME}:${UPLOAD_SERVER_BUILDS_DIR}/" | tr -s ' ' | cut -d ' ' -f 5 | sort -g | tail -n1)
-BUILD_DIR_PATH="../to_build/${BUILD_DIR_NAME}"
+BUILD_DIR_PATH="../to_build/${TRIGGERED_BUILD_NUMBER_build_host_os}"
 
 # update weekly build dir and latest weekly build
 ln -s "$BUILD_DIR_PATH" "$WEEKLY_DIR_NAME"


### PR DESCRIPTION
The trigger_weekly_host_os_build job used to get the latest
build_host_os build number by checking for the most recent directory
in the upload server (with rsync --list-only). This worked fine until
we started running build_host_os builds concurrently. Now, another
unrelated build_host_os build might appear in the upload server before
the rsync runs and the 'latest' symlink created by
trigger_weekly_host_os_build would be wrong.

This patch uses the variable TRIGGERED_BUILD_NUMBER_build_host_os
provided by the Parameterized Trigger plugin to avoid the issue
mentioned above.