### PR TITLE
Set hostos repository priority

### DIFF
--- a/jenkins_jobs/upload_build_artifacts/script.sh
+++ b/jenkins_jobs/upload_build_artifacts/script.sh
@@ -23,6 +23,7 @@ echo -e """[hostos]
 name=hostos
 baseurl=http://${UPLOAD_SERVER_HOST_NAME}${UPLOAD_SERVER_BUILDS_DIR}/${BUILD_JOB_NUMBER}/repository
 enabled=1
+priority=1
 gpgcheck=0""" > hostos.repo
 
 rsync -e "ssh -i $HOME/.ssh/${UPLOAD_SERVER_USER_NAME}_id_rsa" \


### PR DESCRIPTION
To ensure our packages take precedence over CentOS ones when conflicts
arise, we are using the Yum priorities plugin. One step of the
plugin's setup is setting repository priority in the .repo file