### PR TITLE
Update build_host_os artifacts with missing mock logs

### DIFF
--- a/jenkins_jobs/build_host_os.groovy
+++ b/jenkins_jobs/build_host_os.groovy
@@ -37,7 +37,7 @@ job('build_host_os') {
     archiveArtifacts('SUCCESS')
     archiveArtifacts('repository/')
     archiveArtifacts {
-      pattern('build/*/build.log')
+      pattern('build/*/*.log')
       allowEmpty()
     }
     downstreamParameterized {


### PR DESCRIPTION
Mock generates three log files: build.log, root.log and state.log. We
were just archiving the first one so I'm adding the other ones for
completion.