### PR TITLE
Update VERSIONS_REPO_DIR in build_host_os job

### DIFF
--- a/jenkins_jobs/build_host_os/script.sh
+++ b/jenkins_jobs/build_host_os/script.sh
@@ -1,4 +1,4 @@
-VERSIONS_REPO_DIR="components"
+VERSIONS_REPO_DIR=$(basename $VERSIONS_REPO_URL .git)
 MOCK_CONFIG_FILE="extras/centOS/7/mock/epel-7-ppc64le.cfg"
 MAIN_CENTOS_REPO_RELEASE_URL="http://mirror.centos.org/altarch/7"
 


### PR DESCRIPTION
Builds code now clones repositories into a directory with the same
name of the git repository (git clone's default) so let's reflect this
in the VERSIONS_REPO_DIR variable.