### PR TITLE
Execute upgrade-versions on nightly builds

### DIFF
--- a/jenkins_jobs/trigger_nightly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_nightly_host_os_build.groovy
@@ -4,6 +4,12 @@ job('trigger_nightly_host_os_build') {
     stringParam('GITHUB_ORGANIZATION_NAME',
 		"${GITHUB_ORGANIZATION_NAME}",
 		'GitHub organization from where the Host OS repositories will be checked out.')
+    stringParam('GITHUB_BOT_NAME', "${GITHUB_BOT_NAME}",
+		'Name of the GitHub user to create commits automatically.')
+    stringParam('GITHUB_BOT_USER_NAME', "${GITHUB_BOT_USER_NAME}",
+		'User name of the GitHub user to create commits automatically.')
+    stringParam('GITHUB_BOT_EMAIL', "${GITHUB_BOT_EMAIL}",
+		'Email of the GitHub user to create commits automatically')
     stringParam('UPLOAD_SERVER_HOST_NAME', "${UPLOAD_SERVER_HOST_NAME}",
 		'Host name of the target server to upload build results.')
     stringParam('UPLOAD_SERVER_USER_NAME',
@@ -40,9 +46,9 @@ job('trigger_nightly_host_os_build') {
 	     'https://github.com/${GITHUB_ORGANIZATION_NAME}/builds.git',
 	     BUILDS_REPO_COMMIT: 'master',
 	     VERSIONS_REPO_URL:
-	     'https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git',
-             VERSIONS_REPO_COMMIT: 'master',
+	     'https://github.com/${GITHUB_BOT_USER_NAME}/versions.git',
              EXTRA_PARAMETERS: '--mock-args "--enable-plugin=tmpfs --plugin-option=tmpfs:keep_mounted=True --plugin-option=tmpfs:max_fs_size=32g --plugin-option=tmpfs:required_ram_mb=39800 --with tests"'])
+          propertiesFile("BUILD_PARAMETERS", true)
 	}
       }
     }

--- a/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
@@ -1,2 +1,15 @@
 RELEASE_DATE=$(date +%Y-%m-%d)
+COMMIT_BRANCH="nightly-${RELEASE_DATE}"
+
+# Upgrade versions
+# sudo yum install rpmdevtools
+python host_os.py \
+   --verbose \
+   upgrade-versions \
+       --committer-name "$GITHUB_BOT_NAME" \
+       --committer-email "$GITHUB_BOT_EMAIL" \
+       --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
+       --push-repo-branch "$COMMIT_BRANCH"
+
+echo "VERSIONS_REPO_COMMIT=$COMMIT_BRANCH" > BUILD_PARAMETERS
 echo "$RELEASE_DATE" > NIGHTLY_DIR_NAME


### PR DESCRIPTION
Nightly builds are currently generated with the master branch of builds and versions repository. It would be better if it executed the upgrade-versions command to get the latest commits, so the developers could install the updated RPMs before the weekly releases.