### PR TITLE
Add trigger iso job

### DIFF
--- a/jenkins_jobs/trigger_host_os_build_from_builds_repo.groovy
+++ b/jenkins_jobs/trigger_host_os_build_from_builds_repo.groovy
@@ -23,6 +23,7 @@ job('trigger_host_os_build_from_builds_repo') {
       extensions {
 	commitStatus {
 	  context('Build Host OS')
+	  statusUrl('${JENKINS_URL}/job/build_host_os/${TRIGGERED_BUILD_NUMBER_build_host_os}')
 	}
       }
     }

--- a/jenkins_jobs/trigger_host_os_build_from_versions_repo.groovy
+++ b/jenkins_jobs/trigger_host_os_build_from_versions_repo.groovy
@@ -23,6 +23,7 @@ job('trigger_host_os_build_from_versions_repo') {
       extensions {
 	commitStatus {
 	  context('Build Host OS')
+	  statusUrl('${JENKINS_URL}/job/build_host_os/${TRIGGERED_BUILD_NUMBER_build_host_os}')
 	}
       }
     }

--- a/jenkins_jobs/trigger_host_os_iso_build_from_versions_repo.groovy
+++ b/jenkins_jobs/trigger_host_os_iso_build_from_versions_repo.groovy
@@ -1,0 +1,57 @@
+job('trigger_host_os_iso_build_from_versions_repo') {
+  label('!master')
+  logRotator {
+    numToKeep(30)
+  }
+  concurrentBuild()
+  throttleConcurrentBuilds {
+    maxPerNode(1)
+  }
+  parameters {
+    stringParam('sha1', '', 'SHA-1 of the commit to build.')
+    stringParam('GITHUB_ORGANIZATION_NAME',
+		"${GITHUB_ORGANIZATION_NAME}",
+		'GitHub organization from where the Host OS repositories will be checked out.')
+  }
+  properties {
+    githubProjectUrl("https://github.com/${GITHUB_ORGANIZATION_NAME}/versions/")
+  }
+  triggers {
+    githubPullRequest {
+      userWhitelist("${GHPRB_ADMIN_USER}")
+      orgWhitelist("${GHPRB_ADMIN_ORGANIZATION}")
+      allowMembersOfWhitelistedOrgsAsAdmin()
+      cron('H/5 * * * *')
+      triggerPhrase('.*start\\W+iso.*')
+      onlyTriggerPhrase()
+      extensions {
+	commitStatus {
+	  context('Build Host OS ISO')
+	  statusUrl('${JENKINS_URL}/job/build_host_os_iso/${TRIGGERED_BUILD_NUMBER_build_host_os_iso}')
+	}
+      }
+    }
+  }
+  steps {
+    shell(readFileFromWorkspace(
+	    'jenkins_jobs/trigger_host_os_iso_build_from_versions_repo/script.sh'))
+    downstreamParameterized {
+      trigger('build_host_os_iso') {
+	block {
+	  buildStepFailure('FAILURE')
+	  failure('FAILURE')
+	  unstable('UNSTABLE')
+	}
+	parameters {
+	  propertiesFile("BUILD_PARAMETERS", true)
+	}
+      }
+    }
+  }
+  wrappers {
+    timestamps()
+    credentialsBinding {
+      usernamePassword('GITHUB_USER_NAME', 'GITHUB_PASSWORD', 'github-user-pass-credentials')
+    }
+  }
+}

--- a/jenkins_jobs/trigger_host_os_iso_build_from_versions_repo/script.sh
+++ b/jenkins_jobs/trigger_host_os_iso_build_from_versions_repo/script.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+set -x
+
+
+LISTENED_CONTEXT="Build Host OS"
+
+
+get_build_state(){
+    # this will evaluate the queried keys as variables: state=<state>,
+    # target_url=<url>
+    eval $(github_api "$GITHUB_USER_NAME" "$GITHUB_PASSWORD" \
+                      query_status "${GITHUB_ORGANIZATION_NAME}/versions" \
+                      "$ghprbPullId" "$LISTENED_CONTEXT" --state \
+                      --target-url || echo "exit 1")
+}
+
+get_pr_state(){
+    # this will evaluate the queried keys as variables: state=<state>,
+    # title=<title>
+    eval $(github_api "$GITHUB_USER_NAME" "$GITHUB_PASSWORD" \
+                      query_pr "${GITHUB_ORGANIZATION_NAME}/versions" \
+                      "$ghprbPullId" --state --title || echo "exit 1")
+}
+
+state="pending"
+get_build_state
+while [ $state == "pending" ]; do
+    echo "Waiting for $LISTENED_CONTEXT to finish..."
+    echo "$target_url"
+    sleep 1m
+    get_build_state
+done
+
+if [ "$state" == "failure" -o "$state" == "error" ]; then
+    echo "$LISTENED_CONTEXT failed, aborting."
+    echo "$target_url."
+    exit 1
+fi
+
+if [ "$state" == "success" ]; then
+    echo "$LISTENED_CONTEXT succeeded."
+    echo "$target_url"
+    get_pr_state
+    if [ "$state" == "closed" ]; then
+        echo "Pull request ${ghprbPullId}: \"${title}\" was closed, aborting."
+        echo "$ghprbPullLink"
+        exit 1
+    fi
+fi
+
+echo "BUILD_JOB_NUMBER=$(basename $target_url)" > BUILD_PARAMETERS
+echo "Triggering ISO build from $target_url ..."
+
+exit 0

--- a/scripts/github_api
+++ b/scripts/github_api
@@ -42,7 +42,8 @@ def _request(auth, method, url, **kwargs):
         dict: HTTP response
     """
     methods = {
-        'POST': requests.post
+        'POST': requests.post,
+        'GET': requests.get,
     }
 
     r = methods[method](url, auth=auth, **kwargs)
@@ -59,18 +60,33 @@ def _request(auth, method, url, **kwargs):
     return response
 
 
+def _print_dict(_dict):
+    """
+    Prints a dict in a key=value format.
+
+    Args:
+        _dict (dict): values to be formatted
+    """
+    for k, v in _dict.items():
+        print '%s="%s"' % (k, v)
+
+
 class PullRequest:
     """
     https://developer.github.com/v3/pulls/
     """
-    def __init__(self, repo):
+    def __init__(self, repo, number=None):
         """
         Args:
             repo (str): git repository path. Format: <repo owner>/<repo>
+            number (int): pull-request number
         """
         self.repo = repo
         self._url = os.path.join(
             API_BASE_URL, "repos/%(repo)s/pulls" % dict(repo=self.repo))
+
+        if number:
+            self._set_attributes(self.get(number))
 
     def open(self, title, body, src_branch, dst_branch):
         """
@@ -93,6 +109,23 @@ class PullRequest:
         self._set_attributes(
             request('POST', self._url, data=json.dumps(payload_body)))
 
+    def get(self, pr_number):
+        """
+        Gets a GitHub pull-request
+
+        Args:
+            pr_number (int): pull-request number
+
+        Returns:
+            dict: pull-request information. See
+                https://developer.github.com/v3/pulls/#get-a-single-pull-request
+        """
+        url = os.path.join(self._url, str(pr_number))
+
+        pr_info = request('GET', url)
+
+        return pr_info
+
     def _set_attributes(self, pr_info):
         """
         Sets this class' attributes
@@ -100,6 +133,7 @@ class PullRequest:
         Args:
             pr_info (dict): information about a GitHub pull request
         """
+
         for k, v in pr_info.items():
             # just set the simple types that can later be accessed by
             # pull_request.attr. Ignore dicts for now because they
@@ -123,6 +157,24 @@ def open_pull_request(title, src_branch, repo, dst_branch, body=""):
     pr.open(title, body, src_branch, dst_branch)
 
 
+def query_pull_request(repo, number, **kwargs):
+    """
+    Handler for the query_pr command. Returns information about a
+    GitHub pull-request.
+
+    Args:
+        repo (str): target repository path. Format: <repo owner>/<repo>
+        number (int): pull-request number
+        kwargs: keys being queried in the form: key=True
+    """
+    pr = PullRequest(repo, number)
+
+    if all(not v for v in kwargs.values()):
+        kwargs['title'] = True
+
+    return {k:getattr(pr, k) for k, v in kwargs.items() if v}
+
+
 if __name__ == '__main__':
     commands = {
         'open_pr': {
@@ -137,6 +189,26 @@ if __name__ == '__main__':
                 (('dst_branch',), dict(metavar='dst-branch',
                     help='pull request destination branch: <branch>')),
                 (('--body',), dict(help='pull request body text')),
+            ],
+        },
+        'query_pr': {
+            'description': "Get information about a GitHub pull-request",
+            'function': query_pull_request,
+            'arguments': [
+                (('repo',), dict(
+                    help='target repository path: <repo owner>/<repo>')),
+                (('number',), dict(help='pull request number', type=int)),
+                (('--title',), dict(
+                    help='get pull request title text', action='store_true')),
+                (('--state',), dict(
+                    help='get pull request state, i.e. open, closed',
+                    action='store_true')),
+                (('--merged',), dict(
+                    help='get whether the pull request is merged',
+                    action='store_true')),
+                (('--mergeable',), dict(
+                    help='get whether the pull request can be merged',
+                    action='store_true')),
             ],
         },
     }
@@ -168,4 +240,6 @@ if __name__ == '__main__':
         if value is None:
             cmd_args.pop(key)
 
-    commands[args.command]['function'](**cmd_args)
+    cmd_output = commands[args.command]['function'](**cmd_args)
+    if cmd_output:
+        _print_dict(cmd_output)

--- a/scripts/github_api
+++ b/scripts/github_api
@@ -71,6 +71,40 @@ def _print_dict(_dict):
         print '%s="%s"' % (k, v)
 
 
+class Status:
+    """
+    https://developer.github.com/v3/repos/statuses/
+    """
+    def __init__(self, repo, reference):
+        """
+        Args:
+            repo (str): target repository path. Format:
+                <repo owner>/<repo>
+            reference (str): git reference or GitHub pull request
+                number
+        """
+        self.ref = reference
+        self._url = os.path.join(
+            API_BASE_URL,
+            "repos/%(repo)s/commits/%(reference)s/status" % dict(
+                repo=repo, reference=reference))
+        self.get()
+
+    def get(self):
+        """
+        Gets the status
+        """
+        status_info = request('GET', self._url)
+
+        self.num_contexts = status_info['total_count']
+
+        self.latest = {}
+        for status in status_info['statuses']:
+            context = status['context']
+            status.pop('context')
+            self.latest[context] = status
+
+
 class PullRequest:
     """
     https://developer.github.com/v3/pulls/
@@ -124,6 +158,8 @@ class PullRequest:
 
         pr_info = request('GET', url)
 
+        self.reference = pr_info['head']['sha']
+
         return pr_info
 
     def _set_attributes(self, pr_info):
@@ -175,6 +211,42 @@ def query_pull_request(repo, number, **kwargs):
     return {k:getattr(pr, k) for k, v in kwargs.items() if v}
 
 
+def query_status(repo, reference, context, **kwargs):
+    """
+    Handler for the query_status command. Returns information about
+    the status of a GitHub issue or pull-request.
+
+    Args:
+        repo (str): target repository path. Format:
+            <repo owner>/<repo>
+        reference (str): git reference. Either a sha1 or a
+            pull-request number
+        context (str): status context to query
+        kwargs: keys being queried in the form: key=True
+    """
+    try:
+        # if we were given a number as the reference, interpret is as
+        # a pull-request number
+        int(reference)
+        pr = PullRequest(repo, reference)
+        reference = pr.reference
+    except:
+        pass
+
+    status = Status(repo, reference)
+    if not status.num_contexts or context not in status.latest:
+        sys.stderr.write('No %s context. Its build might not have spawned yet.' % context)
+        # We don't want to raise an exception here because this kind
+        # of situation happens too often. For instance, every time a
+        # PR is updated or when a build trigger hasn't run yet.
+        return
+
+    if all(not v for v in kwargs.values()):
+        kwargs['state'] = True
+
+    return {k:status.latest[context][k] for k, v in kwargs.items() if v}
+
+
 if __name__ == '__main__':
     commands = {
         'open_pr': {
@@ -211,6 +283,28 @@ if __name__ == '__main__':
                     action='store_true')),
             ],
         },
+        'query_status': {
+            'description': ("Get information about the status of a GitHub "
+                            "reference. This refers to the 'votes' that a "
+                            "commit or pull-request receives"),
+            'function': query_status,
+            'arguments': [
+                (('repo',), dict(
+                    help='target repository path: <repo owner>/<repo>')),
+                (('reference',), dict(
+                    help=("git reference. Either a sha1 or a "
+                          "pull-request number"))),
+                (('context',), dict(
+                    help=("status context to query. This is the 'name' "
+                          "of the status, e.g. 'Pylint'"))),
+                (('--target-url',), dict(
+                    help='URL to the build output', action='store_true')),
+                (('--state',), dict(
+                    help=('pull request state, i.e. success, failure, '
+                          'error, pending'),
+                    action='store_true')),
+            ],
+        }
     }
 
     parser = argparse.ArgumentParser(description='Wrapper to GitHub API')


### PR DESCRIPTION
This allows us to start a build_host_os_iso build with a comment in the pull-request. This job is a bit different from the other triggers because it waits until the corresponding build_host_os build finishes to get its build id and use it during its own build.