### PR TITLE
Fix whitespace in jobs scripts

### DIFF
--- a/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
@@ -5,12 +5,12 @@ COMMIT_BRANCH="nightly-${RELEASE_DATE}"
 # Upgrade versions
 # sudo yum install rpmdevtools
 python host_os.py \
-   --verbose \
-   upgrade-versions \
-       --updater-name "$GITHUB_BOT_NAME" \
-       --updater-email "$GITHUB_BOT_EMAIL" \
-       --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
-       --push-repo-branch "$COMMIT_BRANCH"
+       --verbose \
+       upgrade-versions \
+           --updater-name "$GITHUB_BOT_NAME" \
+           --updater-email "$GITHUB_BOT_EMAIL" \
+           --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
+           --push-repo-branch "$COMMIT_BRANCH"
 
 echo "VERSIONS_REPO_COMMIT=$COMMIT_BRANCH" > BUILD_PARAMETERS
 echo "$RELEASE_DATE" > NIGHTLY_DIR_NAME

--- a/jenkins_jobs/trigger_weekly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/pre_build_script.sh
@@ -5,22 +5,22 @@ COMMIT_BRANCH="weekly-${RELEASE_DATE}"
 # Upgrade versions
 # sudo yum install rpmdevtools
 python host_os.py \
-   --verbose \
-   upgrade-versions \
-       --updater-name "$GITHUB_BOT_NAME" \
-       --updater-email "$GITHUB_BOT_EMAIL" \
-       --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
-       --push-repo-branch "$COMMIT_BRANCH"
+       --verbose \
+       upgrade-versions \
+           --updater-name "$GITHUB_BOT_NAME" \
+           --updater-email "$GITHUB_BOT_EMAIL" \
+           --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
+           --push-repo-branch "$COMMIT_BRANCH"
 
 python host_os.py \
-    --verbose \
-    release-notes \
-        --build-versions-repository-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
-	--build-version "$COMMIT_BRANCH" \
-	--updater-name "$GITHUB_BOT_NAME" \
-	--updater-email "$GITHUB_BOT_EMAIL" \
-	--push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/${GITHUB_ORGANIZATION_NAME}.github.io.git" \
-	--push-repo-branch "$COMMIT_BRANCH"
+       --verbose \
+       release-notes \
+           --build-versions-repository-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \
+           --build-version "$COMMIT_BRANCH" \
+           --updater-name "$GITHUB_BOT_NAME" \
+           --updater-email "$GITHUB_BOT_EMAIL" \
+           --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/${GITHUB_ORGANIZATION_NAME}.github.io.git" \
+           --push-repo-branch "$COMMIT_BRANCH"
 
 echo "VERSIONS_REPO_COMMIT=$COMMIT_BRANCH" > BUILD_PARAMETERS
 echo "$RELEASE_DATE" > WEEKLY_DIR_NAME


### PR DESCRIPTION
No tabs, 4 spaces, continuation lines indented at the same level of
first argument.

For commands that have subcommands, subcommand arguments indented at 4
spaces from the subcommand name.

if foo; then
....python host_os.py arg1 arg2 arg3 \
...........arg4 arg5 \
...........subcommand subarg1 \
......................subarg2 subarg3
fi