### PR TITLE
Fix github-api-wrapper role

### DIFF
--- a/ansible/roles/github-api-wrapper/tasks/main.yaml
+++ b/ansible/roles/github-api-wrapper/tasks/main.yaml
@@ -1,18 +1,10 @@
 ---
-- name: Get git repository root directory
-  shell: git rev-parse --show-toplevel | tr -d '\n'
-  register: git_repo_root_dir
-  args:
-    chdir: "{{playbook_dir}}"
-  tags:
-    - setup
-
 - name: Install GitHub API wrapper
   copy:
     src={{item.src}} dest={{item.dest}}
     owner={{item.owner}} group={{item.group}} mode={{item.mode}}
   with_items:
-    - { src: "{{git_repo_root_dir.stdout}}/scripts/github_api",
+    - { src: "{{playbook_dir}}/../scripts/github_api",
         dest: "/usr/local/bin",
         owner: jenkins, group: jenkins, mode: "0555" }
   tags:


### PR DESCRIPTION
Ansible scripts can be run remotely so using chdir doesn't work
because it runs on the host running the playbook.

This patch fix this issue but limits the ability of moving the
playbook files in (or out of) the infrastructure repo. However that
shouldn't be a problem as moving files is a modification to the git
repo so another could be made to fix the path in the role.