### PR TITLE
Allow the use of custom 'versions' url/branch during periodic builds

### DIFF
--- a/jenkins_jobs/trigger_nightly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_nightly_host_os_build.groovy
@@ -10,6 +10,9 @@ job('trigger_nightly_host_os_build') {
     stringParam('BUILDS_REPOSITORY_BRANCH',
 		"master",
 		'Branch of the builds repository to clone and pass to the build jobs.')
+    stringParam('VERSIONS_REPOSITORY_BRANCH',
+		"master",
+		"Branch of the versions repository on which to base the update of packages' versions.")
     stringParam('GITHUB_BOT_NAME', "${GITHUB_BOT_NAME}",
 		'Name of the GitHub user to create commits automatically.')
     stringParam('GITHUB_BOT_USER_NAME', "${GITHUB_BOT_USER_NAME}",

--- a/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
@@ -1,4 +1,4 @@
-VERSIONS_REPO_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
+VERSIONS_REPOSITORY_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
 RELEASE_DATE=$(date +%Y-%m-%d)
 COMMIT_BRANCH="nightly-${RELEASE_DATE}"
 
@@ -7,6 +7,8 @@ COMMIT_BRANCH="nightly-${RELEASE_DATE}"
 python host_os.py \
        --verbose \
        upgrade-versions \
+           --build-versions-repository-url "$VERSIONS_REPOSITORY_URL" \
+           --build-version "$VERSIONS_REPOSITORY_BRANCH" \
            --updater-name "$GITHUB_BOT_NAME" \
            --updater-email "$GITHUB_BOT_EMAIL" \
            --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \

--- a/jenkins_jobs/trigger_weekly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_weekly_host_os_build.groovy
@@ -10,6 +10,9 @@ job('trigger_weekly_host_os_build') {
     stringParam('BUILDS_REPOSITORY_BRANCH',
 		"master",
 		'Branch of the builds repository to clone and pass to the build jobs.')
+    stringParam('VERSIONS_REPOSITORY_BRANCH',
+		"master",
+		"Branch of the versions repository on which to base the update of packages' versions.")
     stringParam('GITHUB_BOT_NAME', "${GITHUB_BOT_NAME}",
 		'Name of the GitHub user to create commits automatically.')
     stringParam('GITHUB_BOT_USER_NAME', "${GITHUB_BOT_USER_NAME}",

--- a/jenkins_jobs/trigger_weekly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/pre_build_script.sh
@@ -1,4 +1,4 @@
-VERSIONS_REPO_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
+VERSIONS_REPOSITORY_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
 RELEASE_DATE=$(date +%Y-%m-%d)
 COMMIT_BRANCH="weekly-${RELEASE_DATE}"
 
@@ -18,6 +18,8 @@ create_pull_request() {
 python host_os.py \
        --verbose \
        upgrade-versions \
+           --build-versions-repository-url "$VERSIONS_REPOSITORY_URL" \
+           --build-version "$VERSIONS_REPOSITORY_BRANCH" \
            --updater-name "$GITHUB_BOT_NAME" \
            --updater-email "$GITHUB_BOT_EMAIL" \
            --push-repo-url "ssh://git@github.com/${GITHUB_BOT_USER_NAME}/versions.git" \


### PR DESCRIPTION
Currently the upgrade_versions command does not receive the 'versions'
repository url and branch via parameter. This is not ideal because in
a development environment using a custom GitHub user/organization, the
command would still clone open-power-host-os/versions and that is
misleading.