### PR TITLE
Ensure release notes use the same commit ids as the build

### DIFF
--- a/jenkins_jobs/trigger_weekly_host_os_build/script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/script.sh
@@ -149,11 +149,12 @@ VERSIONS_PR_NUMBER=$pr_number
 
 write_comment "$BUILD_ISO_TRIGGER_PHRASE"
 
+wait_pull_request_merge $VERSIONS_PR_NUMBER $VERSIONS_REPO_NAME
+
 create_release_notes
 create_pull_request $GITHUB_IO_REPO_NAME
 GITHUB_IO_PR_NUMBER=$pr_number
 
-wait_pull_request_merge $VERSIONS_PR_NUMBER $VERSIONS_REPO_NAME
 wait_pull_request_merge $GITHUB_IO_PR_NUMBER $GITHUB_IO_REPO_NAME
 
 fetch_build_timestamp

--- a/jenkins_jobs/trigger_weekly_host_os_build/script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/script.sh
@@ -102,14 +102,15 @@ wait_pull_request_merge() {
     fi
 }
 
-fetch_build_timestamp() {
+fetch_build_info() {
     get_build_state
     local artifacts_src_build_number=$(basename $target_url)
     local artifacts_url=$(basename $JENKINS_URL):${JENKINS_HOME}/jobs/build_host_os/builds/${artifacts_src_build_number}/archive
 
     rsync -e "ssh -i ${HOME}/.ssh/jenkins_id_rsa" \
               --verbose --compress --stats --times --perms \
-              $artifacts_url/BUILD_TIMESTAMP .
+              $artifacts_url/BUILD_TIMESTAMP \
+              $artifacts_url/BUILDS_REPO_COMMIT .
 }
 
 create_symlinks() {
@@ -151,12 +152,18 @@ write_comment "$BUILD_ISO_TRIGGER_PHRASE"
 
 wait_pull_request_merge $VERSIONS_PR_NUMBER $VERSIONS_REPO_NAME
 
+fetch_build_info
+
+# checkout the builds repo commit that was used by the build job
+# because the branch might have moved during the time it takes to
+# generate the build
+git checkout $(cat BUILDS_REPO_COMMIT)
+
 create_release_notes
 create_pull_request $GITHUB_IO_REPO_NAME
 GITHUB_IO_PR_NUMBER=$pr_number
 
 wait_pull_request_merge $GITHUB_IO_PR_NUMBER $GITHUB_IO_REPO_NAME
 
-fetch_build_timestamp
 create_symlinks
 tag_git_repos $VERSIONS_PUSH_URL $GITHUB_IO_PUSH_URL $BUILDS_PUSH_URL


### PR DESCRIPTION
Currently the release notes creation is running as soon as the GitHub pull request that triggers the build job is created, which means that it is probably being run before the build job has started. If the builds repo branch moves in the meantime, the release notes will have the wrong commit id listed.

This PR moves the release notes creation to after the build and makes the trigger job checkout the same commit id as the build job for both versions and builds repos.