### PR TITLE
Replace tab with spaces in YAML

### DIFF
--- a/ansible/roles/ssh/tasks/main.yaml
+++ b/ansible/roles/ssh/tasks/main.yaml
@@ -5,7 +5,7 @@
     mode={{item.mode}} state=directory
   with_items:
     - { name: "{{jenkins_home_dir}}/.ssh", owner: jenkins, group: jenkins,
-      	mode: "0700" }
+        mode: "0700" }
   tags:
     - setup
 


### PR DESCRIPTION
Replace tab with spaces in YAML to avoid the following error when running
`ansible-playbook --private-key=~/.ssh/id_rsa -i hosts.ini --tags=setup jenkins-master.yaml`
with ansible-playbook 2.3.0.0:

```
ERROR! Syntax Error while loading YAML.

The error appears to have been in '/home/muriloo/sources/open-power-host-os/infrastructure/ansible/roles/ssh/tasks/main.yaml': line 8, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - { name: "{{jenkins_home_dir}}/.ssh", owner: jenkins, group: jenkins,
      	mode: "0700" }
      ^ here
There appears to be a tab character at the start of the line.

YAML does not use tabs for formatting. Tabs should be replaced with spaces.
```

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>