### PR TITLE
Update build directory path

### DIFF
--- a/jenkins_jobs/trigger_nightly_host_os_build/post_build_script.sh
+++ b/jenkins_jobs/trigger_nightly_host_os_build/post_build_script.sh
@@ -1,6 +1,6 @@
 NIGHTLY_DIR_NAME=$(cat NIGHTLY_DIR_NAME)
 BUILD_TIMESTAMP=$(cat BUILD_TIMESTAMP)
-BUILD_DIR_PATH="../to_build/${BUILD_TIMESTAMP}"
+BUILD_DIR_PATH="../builds/${BUILD_TIMESTAMP}"
 
 # update nightly build dir and latest nightly build
 ln -s "$BUILD_DIR_PATH" "$NIGHTLY_DIR_NAME"

--- a/jenkins_jobs/trigger_weekly_host_os_build/script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/script.sh
@@ -127,7 +127,7 @@ fetch_build_info() {
 }
 
 create_symlinks() {
-    local build_dir_path="../to_build/$BUILD_TIMESTAMP"
+    local build_dir_path="../builds/$BUILD_TIMESTAMP"
 
     ln -s "$build_dir_path" "$RELEASE_DATE"
     ln -s "$RELEASE_DATE" latest


### PR DESCRIPTION
Rename build directory path to `builds`, a more meaningful name to describe the
place where all builds are uploaded to.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>