### PR TITLE
Update Jenkins jobs to use new path scripts/validate_*.py

### DIFF
--- a/jenkins_jobs/build_host_os/script.sh
+++ b/jenkins_jobs/build_host_os/script.sh
@@ -3,7 +3,7 @@ TIMESTAMP=$(date --utc +'%Y-%m-%dT%H:%M:%S.%N')
 BUILDS_WORKSPACE_DIR="/var/lib/host-os"
 VERSIONS_REPO_DIR="$(basename $VERSIONS_REPO_URL .git)_build-packages"
 VERSIONS_REPO_PATH="$BUILDS_WORKSPACE_DIR/repositories/$VERSIONS_REPO_DIR"
-MOCK_CONFIG_FILE="mock_configs/CentOS/7/CentOS-7-ppc64le.cfg"
+MOCK_CONFIG_FILE="config/mock/CentOS/7/CentOS-7-ppc64le.cfg"
 MAIN_CENTOS_REPO_RELEASE_URL="http://mirror.centos.org/altarch/7"
 
 # There is a symlink from the workdir to this directory. This makes

--- a/jenkins_jobs/build_host_os_iso/script.sh
+++ b/jenkins_jobs/build_host_os_iso/script.sh
@@ -1,6 +1,6 @@
 VERSIONS_REPO_DIR=$(basename $VERSIONS_REPO_URL .git)
-BUILDS_CONFIG_FILE="config.yaml"
-MOCK_CONFIG_FILE="mock_configs/CentOS/7/build-iso-CentOS-7-ppc64le.cfg"
+BUILDS_CONFIG_FILE="config/host_os.yaml"
+MOCK_CONFIG_FILE="config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg"
 MAIN_CENTOS_REPO_RELEASE_URL="http://mirror.centos.org/altarch/7"
 MAIN_EPEL_REPO_RELEASE_URL="http://download.fedoraproject.org/pub/epel/7"
 

--- a/jenkins_jobs/build_old_host_os_versions/script.sh
+++ b/jenkins_jobs/build_old_host_os_versions/script.sh
@@ -1,5 +1,5 @@
-MOCK_CONFIG_FILE="mock_configs/CentOS/7/CentOS-7-ppc64le.cfg"
-BUILD_CONFIG_FILE="config.yaml"
+MOCK_CONFIG_FILE="config/mock/CentOS/7/CentOS-7-ppc64le.cfg"
+BUILD_CONFIG_FILE="config/host_os.yaml"
 CENTOS_7_YUM_REPO_URL="http://mirror.centos.org/altarch/7"
 CENTOS_7_2_YUM_REPO_URL="http://vault.centos.org/altarch/7.2.1511/"
 VERSIONS_REPO_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
@@ -19,7 +19,7 @@ sed -i \
     $BUILD_CONFIG_FILE
 # -E is to avoid escaping parenthesis
 sed -i -E \
-    "s|  '7': (\"\./mock_configs.*)|  '7.2': \1|" \
+    "s|  '7': (\"\./config/mock.*)|  '7.2': \1|" \
     $BUILD_CONFIG_FILE
 
 # clean yum repos cache to avoid conflict with newer CentOS versions content

--- a/jenkins_jobs/trigger_rpmlint_from_versions_repo/script.sh
+++ b/jenkins_jobs/trigger_rpmlint_from_versions_repo/script.sh
@@ -3,4 +3,4 @@ cd versions
 git fetch origin refs/pull/*:refs/remotes/origin/pr/*
 git checkout $sha1
 cd ..
-./validate_rpm_specs.py -d versions
+./scripts/validate_rpm_specs.py -d versions

--- a/jenkins_jobs/trigger_yamllint_from_versions_repo/script.sh
+++ b/jenkins_jobs/trigger_yamllint_from_versions_repo/script.sh
@@ -3,4 +3,4 @@ cd versions
 git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
 git checkout $sha1
 cd ..
-./validate_yamls.py -d versions
+./scripts/validate_yamls.py -d versions


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/247

Update Jenkins jobs to point to new path `scripts/validate_*.py`