### PR TITLE
Fetch builds repository before building release notes

### DIFF
--- a/jenkins_jobs/trigger_weekly_host_os_build/script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/script.sh
@@ -164,6 +164,7 @@ fetch_build_info
 # checkout the builds repo commit that was used by the build job
 # because the branch might have moved during the time it takes to
 # generate the build
+git fetch origin
 git checkout $BUILDS_REPO_COMMIT
 
 create_release_notes


### PR DESCRIPTION
If the master branch has been updated during the weekly job, the
repository needs to be fetched prior to checking out the built commit.