### PR TITLE
Parameterize the builds workspace directory

### DIFF
--- a/ansible/roles/builds/tasks/main.yaml
+++ b/ansible/roles/builds/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create Host OS build directories
   file:
-    name=/var/lib/host-os state=directory
+    name={{builds_workspace_dir}} state=directory
     owner={{builder_user_name}} group=mock
   tags:
     - setup
@@ -9,7 +9,7 @@
 - name: Create a symbolic link for the mock build directory
   file:
     src="{{builder_home_dir}}/workspace/build_host_os/mock_build"
-    dest=/var/lib/host-os/mock_build
+    dest={{builds_workspace_dir}}/mock_build
     state=link force=yes
     owner={{builder_user_name}} group=mock
   tags:

--- a/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
+++ b/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
@@ -90,6 +90,11 @@
           <description>Directory in the target server to upload nightly build results.</description>
           <defaultValue>{{upload_server_nightly_dir_path}}</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>BUILDS_WORKSPACE_DIR</name>
+          <description>Workspace directory where builds will happen.</description>
+          <defaultValue>{{builds_workspace_dir}}</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -15,3 +15,5 @@ upload_server_user_name:
 upload_server_builds_dir_path:
 upload_server_weekly_dir_path:
 upload_server_nightly_dir_path:
+
+builds_workspace_dir: /var/lib/host-os

--- a/jenkins_jobs/build_host_os.groovy
+++ b/jenkins_jobs/build_host_os.groovy
@@ -13,6 +13,8 @@ job('build_host_os') {
 		'URL of the builds repository.')
     stringParam('BUILDS_REPO_REFERENCE', 'origin/master',
 		'Git reference to checkout from the builds repository.')
+    stringParam('BUILDS_WORKSPACE_DIR', "${BUILDS_WORKSPACE_DIR}",
+    'Workspace directory where builds will happen.')
     stringParam('VERSIONS_REPO_URL',
 		"https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git",
 		'URL of the versions repository.')

--- a/jenkins_jobs/build_host_os/script.sh
+++ b/jenkins_jobs/build_host_os/script.sh
@@ -1,6 +1,5 @@
 # ISO 8601 date with nanoseconds precision
 TIMESTAMP=$(date --utc +'%Y-%m-%dT%H:%M:%S.%N')
-BUILDS_WORKSPACE_DIR="/var/lib/host-os"
 VERSIONS_REPO_DIR="$(basename $VERSIONS_REPO_URL .git)_build-packages"
 VERSIONS_REPO_PATH="$BUILDS_WORKSPACE_DIR/repositories/$VERSIONS_REPO_DIR"
 MOCK_CONFIG_FILE="config/mock/CentOS/7/CentOS-7-ppc64le.cfg"

--- a/jenkins_jobs/trigger_nightly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_nightly_host_os_build.groovy
@@ -10,6 +10,8 @@ job('trigger_nightly_host_os_build') {
     stringParam('BUILDS_REPOSITORY_BRANCH',
 		"master",
 		'Branch of the builds repository to clone and pass to the build jobs.')
+    stringParam('BUILDS_WORKSPACE_DIR', "${BUILDS_WORKSPACE_DIR}",
+    'Workspace directory where builds will happen.')
     stringParam('VERSIONS_REPOSITORY_BRANCH',
 		"master",
 		"Branch of the versions repository on which to base the update of packages' versions.")

--- a/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
+++ b/jenkins_jobs/trigger_nightly_host_os_build/pre_build_script.sh
@@ -1,5 +1,4 @@
 VERSIONS_REPOSITORY_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
-BUILDS_WORKSPACE_DIR="/var/lib/host-os"
 RELEASE_DATE=$(date +%Y-%m-%d)
 COMMIT_BRANCH="nightly-${RELEASE_DATE}"
 

--- a/jenkins_jobs/trigger_weekly_host_os_build.groovy
+++ b/jenkins_jobs/trigger_weekly_host_os_build.groovy
@@ -10,6 +10,8 @@ job('trigger_weekly_host_os_build') {
     stringParam('BUILDS_REPOSITORY_BRANCH',
 		"master",
 		'Branch of the builds repository to clone and pass to the build jobs.')
+    stringParam('BUILDS_WORKSPACE_DIR', "${BUILDS_WORKSPACE_DIR}",
+    'Workspace directory where builds will happen.')
     stringParam('VERSIONS_REPOSITORY_BRANCH',
 		"master",
 		"Branch of the versions repository on which to base the update of packages' versions.")

--- a/jenkins_jobs/trigger_weekly_host_os_build/script.sh
+++ b/jenkins_jobs/trigger_weekly_host_os_build/script.sh
@@ -3,7 +3,6 @@ set -e
 MAIN_REPO_URL_PREFIX="ssh://git@github.com/${GITHUB_ORGANIZATION_NAME}"
 PUSH_REPO_URL_PREFIX="ssh://git@github.com/${GITHUB_BOT_USER_NAME}"
 
-BUILDS_WORKSPACE_DIR="/var/lib/host-os"
 REPOSITORIES_PATH="${BUILDS_WORKSPACE_DIR}/repositories"
 
 VERSIONS_REPO_NAME="versions"


### PR DESCRIPTION
Parameterize the builds workspace directory

Add new parameter BUILDS_WORKSPACE_DIR in the seed_job to represent the
workspace directory where builds will happen.

The builds workspace directory was hard-coded to /var/lib/host-os among
build_host_os, trigger_nightly_host_os_build, and trigger_weekly_host_os_build
jobs. Adding the possibility to configure it during the setup with Ansible,
makes the setup more flexible.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>