### PR TITLE
Revert "Update ISO checksum filename"

### DIFF
--- a/jenkins_jobs/upload_iso.groovy
+++ b/jenkins_jobs/upload_iso.groovy
@@ -30,7 +30,7 @@ job('upload_iso') {
         buildNumber('$BUILD_ISO_JOB_NUMBER')
       }
       includePatterns('*.iso')
-      includePatterns('*.iso.sha256')
+      includePatterns('*-CHECKSUM')
     }
     shell(readFileFromWorkspace('jenkins_jobs/upload_iso/script.sh'))
   }

--- a/jenkins_jobs/upload_iso/script.sh
+++ b/jenkins_jobs/upload_iso/script.sh
@@ -14,4 +14,4 @@ mkdir iso
 rsync_upload --recursive iso
 
 rsync_upload *.iso
-rsync_upload *.iso.sha256
+rsync_upload *-CHECKSUM


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/257

This reverts commit 9db0b5c946a1f1e27834f2faee9e1e8a4273230d.

Revert above commit based on
https://github.com/open-power-host-os/builds/pull/257

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>