### PR TITLE
Update BUILD_TIMESTAMP file content

### DIFF
--- a/jenkins_jobs/build_host_os/script.sh
+++ b/jenkins_jobs/build_host_os/script.sh
@@ -1,5 +1,3 @@
-# ISO 8601 date with nanoseconds precision
-TIMESTAMP=$(date --utc +'%Y-%m-%dT%H:%M:%S.%N')
 VERSIONS_REPO_DIR="$(basename $VERSIONS_REPO_URL .git)_build-packages"
 VERSIONS_REPO_PATH="$BUILDS_WORKSPACE_DIR/repositories/$VERSIONS_REPO_DIR"
 MOCK_CONFIG_FILE="config/mock/CentOS/7/CentOS-7-ppc64le.cfg"
@@ -44,6 +42,7 @@ versions_repo_commit=$(git show-ref --hash "$VERSIONS_REPO_REFERENCE" \
 popd
 
 # Create BUILD_TIMESTAMP file with timestamp information
+TIMESTAMP=$(basename $BUILDS_WORKSPACE_DIR/mock_build/*)
 echo "${TIMESTAMP}" > ./BUILD_TIMESTAMP
 echo "$builds_repo_commit" > ./BUILDS_REPO_COMMIT
 echo "$versions_repo_commit" > ./VERSIONS_REPO_COMMIT


### PR DESCRIPTION
Re-using the directory name generated by mock, which is a timestamp, makes the
content of BUILD_TIMESTAMP file consistent between mock and jobs that already
use it as their timestamp.

The timestamp still follows the ISO 8601 format with just less precision, from
nano to micro seconds.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>