### PR TITLE
Specify iso version when building iso

### DIFF
--- a/jenkins_jobs/build_host_os_iso.groovy
+++ b/jenkins_jobs/build_host_os_iso.groovy
@@ -39,6 +39,7 @@ job('build_host_os_iso') {
         buildNumber('$BUILD_JOB_NUMBER')
       }
       includePatterns('repository/')
+      includePatterns('BUILD_TIMESTAMP')
     }
     shell(readFileFromWorkspace('jenkins_jobs/build_host_os_iso/script.sh'))
     shell(readFileFromWorkspace('jenkins_jobs/build_host_os_iso/archive.sh'))

--- a/jenkins_jobs/build_host_os_iso/script.sh
+++ b/jenkins_jobs/build_host_os_iso/script.sh
@@ -1,8 +1,16 @@
 VERSIONS_REPO_DIR=$(basename $VERSIONS_REPO_URL .git)
 BUILDS_CONFIG_FILE="config/host_os.yaml"
+BUILD_TIMESTAMP=$(cat BUILD_TIMESTAMP)
+ISO_VERSION=$BUILD_TIMESTAMP
 MOCK_CONFIG_FILE="config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg"
 MAIN_CENTOS_REPO_RELEASE_URL="http://mirror.centos.org/altarch/7"
 MAIN_EPEL_REPO_RELEASE_URL="http://download.fedoraproject.org/pub/epel/7"
+
+# Format iso version.  Example of expected string:
+# 2017-05-10T12:50:29.163138539
+ISO_VERSION=${ISO_VERSION//-/}
+ISO_VERSION=${ISO_VERSION//:/}
+ISO_VERSION=${ISO_VERSION//.*/}
 
 # Tell mock and pungi to use different CentOS and EPEL mirrors/repos.
 # This could be used to:
@@ -31,6 +39,7 @@ eval python host_os.py \
      --verbose \
      build-iso \
          --packages-dir repository \
+         --iso-version $ISO_VERSION \
          $EXTRA_PARAMETERS
 
 # inform status to upload job

--- a/jenkins_jobs/upload_iso/script.sh
+++ b/jenkins_jobs/upload_iso/script.sh
@@ -6,6 +6,7 @@ ISO_DIR_RSYNC_URL="${BUILD_DIR_RSYNC_URL}/iso"
 rsync_upload() {
     rsync -e "ssh -i ${HOME}/.ssh/${UPLOAD_SERVER_USER_NAME}_id_rsa" \
               --verbose --compress --stats --times --chmod=a+rwx,g+wx,o- \
+              --ignore-existing --itemize-changes \
               $@ $ISO_DIR_RSYNC_URL
 }
 


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/262

This specifies iso version to the build_host_os_iso job; and updates rsync
params of the upload_iso job not to replace existing files on receiver.