### PR TITLE
Add role to configure Jenkins LDAP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Jenkins slave playbook.
 Note: The Jenkins playbooks may fail due to network errors. If you see HTTP
 request errors, try executing them again.
 
+#### Jenkins LDAP authentication
+
+There's an optional Ansible role that configures Jenkins authentication through
+an LDAP server. You'll first need to enable the `configure_ldap` variable in
+the [Jenkins master variables file](ansible/vars-master.yaml) and set the
+variables in the
+[LDAP configuration file](ansible/roles/jenkins-ldap/defaults/main.yaml),
+making sure there's at least one admin user so you are able to access and
+customize Jenkins using the UI. Execute the master playbook as usual and
+answer with `Y` when prompted if you'd like to configure LDAP.
 
 ### Manually setup Jenkins via web UI
 

--- a/ansible/jenkins-master.yaml
+++ b/ansible/jenkins-master.yaml
@@ -13,6 +13,7 @@
     - systemd
     - jenkins-master
     - jenkins-seed-job
+    - { role: jenkins-ldap, when: configure_ldap }
   vars_files:
     - vars.yaml
     - vars-master.yaml

--- a/ansible/roles/jenkins-ldap/defaults/main.yaml
+++ b/ansible/roles/jenkins-ldap/defaults/main.yaml
@@ -1,0 +1,58 @@
+---
+ldap_server:
+ldap_user_search_base:
+ldap_user_search:
+ldap_manager_password_secret:
+jenkins_permissions:
+  admins:
+    users:
+      - admin@example.com
+    permissions:
+      - com.cloudbees.plugins.credentials.CredentialsProvider.Create
+      - com.cloudbees.plugins.credentials.CredentialsProvider.Delete
+      - com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains
+      - com.cloudbees.plugins.credentials.CredentialsProvider.Update
+      - com.cloudbees.plugins.credentials.CredentialsProvider.View
+      - hudson.model.Computer.Build
+      - hudson.model.Computer.Configure
+      - hudson.model.Computer.Connect
+      - hudson.model.Computer.Create
+      - hudson.model.Computer.Delete
+      - hudson.model.Computer.Disconnect
+      - hudson.model.Hudson.Administer
+      - hudson.model.Hudson.Read
+      - hudson.model.Item.Build
+      - hudson.model.Item.Cancel
+      - hudson.model.Item.Configure
+      - hudson.model.Item.Create
+      - hudson.model.Item.Delete
+      - hudson.model.Item.Discover
+      - hudson.model.Item.Read
+      - hudson.model.Item.Workspace
+      - hudson.model.Run.Delete
+      - hudson.model.Run.Replay
+      - hudson.model.Run.Update
+      - hudson.model.View.Configure
+      - hudson.model.View.Create
+      - hudson.model.View.Delete
+      - hudson.model.View.Read
+  authorized:
+    users:
+      - authorized@example.com
+    permissions:
+      - com.cloudbees.plugins.credentials.CredentialsProvider.View
+      - hudson.model.Hudson.Read
+      - hudson.model.Item.Build
+      - hudson.model.Item.Cancel
+      - hudson.model.Item.Discover
+      - hudson.model.Item.Read
+      - hudson.model.Item.Workspace
+      - hudson.model.View.Read
+  viewers:
+    users:
+      - viewer@example.com
+    permissions:
+      - hudson.model.Hudson.Read
+      - hudson.model.Item.Discover
+      - hudson.model.Item.Read
+      - hudson.model.View.Read

--- a/ansible/roles/jenkins-ldap/tasks/main.yaml
+++ b/ansible/roles/jenkins-ldap/tasks/main.yaml
@@ -1,0 +1,45 @@
+---
+- name: Configure LDAP server
+  replace:
+    path: "{{jenkins_home_dir}}/config.xml"
+    regexp: '^(\s*)<securityRealm[\w\W]*</securityRealm>\n'
+    replace: |
+      \1<securityRealm class="hudson.security.LDAPSecurityRealm" plugin="ldap@1.15">
+      \1  <server>{{ldap_server}}</server>
+      \1  <rootDN></rootDN>
+      \1  <inhibitInferRootDN>true</inhibitInferRootDN>
+      \1  <userSearchBase>{{ldap_user_search_base}}</userSearchBase>
+      \1  <userSearch>{{ldap_user_search}}</userSearch>
+      \1  <groupMembershipStrategy class="jenkins.security.plugins.ldap.FromGroupSearchLDAPGroupMembershipStrategy">
+      \1    <filter></filter>
+      \1  </groupMembershipStrategy>
+      \1  <managerPasswordSecret>{{ldap_manager_password_secret}}</managerPasswordSecret>
+      \1  <disableMailAddressResolver>false</disableMailAddressResolver>
+      \1  <displayNameAttributeName>displayname</displayNameAttributeName>
+      \1  <mailAddressAttributeName>mail</mailAddressAttributeName>
+      \1  <userIdStrategy class="jenkins.model.IdStrategy$CaseInsensitive"/>
+      \1  <groupIdStrategy class="jenkins.model.IdStrategy$CaseInsensitive"/>
+      \1  <disableRolePrefixing>false</disableRolePrefixing>
+      \1</securityRealm>
+  notify: restart jenkins
+  tags:
+    - setup
+
+- name: Configure LDAP users permissions
+  replace:
+    path: "{{jenkins_home_dir}}/config.xml"
+    regexp: '^(\s*)<authorizationStrategy[\w\W]*</authorizationStrategy>\n'
+    replace: |
+      #jinja2: lstrip_blocks:True
+      \1<authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">
+        {% for group in jenkins_permissions.values() %}
+        {% for user in group.users %}
+        {% for permission in group.permissions %}
+      \1  <permission>{{permission}}:{{user}}</permission>
+        {% endfor %}
+        {% endfor %}
+        {% endfor %}
+      \1</authorizationStrategy>
+  notify: restart jenkins
+  tags:
+    - setup

--- a/ansible/vars-master.yaml
+++ b/ansible/vars-master.yaml
@@ -7,3 +7,5 @@ jenkins_home_dir: /var/lib/jenkins
 jenkins_bin_dir: /opt/jenkins
 jenkins_port: 8080
 jenkins_local_url: "http://127.0.0.1:{{jenkins_port}}"
+
+configure_ldap: no


### PR DESCRIPTION
This role is optional, because not all users may want to have LDAP
authentication. A simpler authentication model may also be useful in
test environments.