### PR TITLE
Update job to build legacy packages 1.0 and 1.5

### DIFF
--- a/jenkins_jobs/build_old_host_os_versions/script.sh
+++ b/jenkins_jobs/build_old_host_os_versions/script.sh
@@ -1,42 +1,45 @@
 MOCK_CONFIG_FILE="config/mock/CentOS/7/CentOS-7-ppc64le.cfg"
+LEGACY_MOCK_DIR="config/mock/centOS/7.2"
+LEGACY_MOCK_CONFIG_FILE="${LEGACY_MOCK_DIR}/centOS-7.2-ppc64le.cfg"
 BUILD_CONFIG_FILE="config/host_os.yaml"
 CENTOS_7_YUM_REPO_URL="http://mirror.centos.org/altarch/7"
-CENTOS_7_2_YUM_REPO_URL="http://vault.centos.org/altarch/7.2.1511/"
+CENTOS_7_2_YUM_REPO_URL="http://vault.centos.org/altarch/7.2.1511"
 VERSIONS_REPO_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
-TAG_1_0="v1.0.0"
-TAG_1_5="v1.5.0"
+TAG_1_0="hostos-1.0"
+TAG_1_5="hostos-1.5"
+
+# create legacy directories
+mkdir -p $LEGACY_MOCK_DIR
+
+# copy mock config to the legacy location
+cp $MOCK_CONFIG_FILE $LEGACY_MOCK_CONFIG_FILE
 
 # use CentOS 7.2 instead of latest CentOS 7 yum repository
 sed -i \
     "s|${CENTOS_7_YUM_REPO_URL}|${CENTOS_7_2_YUM_REPO_URL}|" \
-    $MOCK_CONFIG_FILE
-
-sed -i \
-    "s|packages_metadata_repo_url:.*|packages_metadata_repo_url: \"$VERSIONS_REPO_URL\"|" \
-    $BUILD_CONFIG_FILE
-sed -i \
-    "s|distro_version:.*|distro_version: \"7.2\"|" \
-    $BUILD_CONFIG_FILE
-# -E is to avoid escaping parenthesis
-sed -i -E \
-    "s|  '7': (\"\./config/mock.*)|  '7.2': \1|" \
-    $BUILD_CONFIG_FILE
+    $LEGACY_MOCK_CONFIG_FILE
 
 # clean yum repos cache to avoid conflict with newer CentOS versions content
 # which may be already in the cache
 mock --scrub all
+mock -r $LEGACY_MOCK_CONFIG_FILE --scrub all
 
 # 1.5
-sed -i \
-    "s|packages_metadata_repo_branch:.*|packages_metadata_repo_branch: \"$TAG_1_5\"|" \
-    $BUILD_CONFIG_FILE
-python host_os.py --verbose build-packages
+python host_os.py \
+       --verbose \
+       --distro-name centOS \
+       --distro-version 7.2 \
+       build-packages \
+       --packages-metadata-repo-branch $TAG_1_5
 
 # 1.0
-sed -i \
-    "s|packages_metadata_repo_branch:.*|packages_metadata_repo_branch: \"$TAG_1_0\"|" \
-    $BUILD_CONFIG_FILE
-python host_os.py --verbose build-packages
+python host_os.py \
+       --verbose \
+       --distro-name centOS \
+       --distro-version 7.2 \
+       build-packages \
+       --packages-metadata-repo-branch $TAG_1_0
 
 # clean yum repos to avoid that future builds which use newer CentOS versions have conflicts
 mock --scrub all
+mock -r $LEGACY_MOCK_CONFIG_FILE --scrub all


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/268

Use hostos-1.x branches; remove some sed commands and use host_os.py arguments.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>