### PR TITLE
Avoid loading groovy files twice

### DIFF
--- a/pipeline/build.groovy
+++ b/pipeline/build.groovy
@@ -1,6 +1,10 @@
 #!groovy
 
+constants = readProperties file: '/etc/jenkins/pipeline_constants.groovy'
+utils = load 'infrastructure/pipeline/lib/utils.groovy'
+
 pipelineStages = load 'infrastructure/pipeline/build/stages.groovy'
+
 
 def execute() {
   timestamps {

--- a/pipeline/build/parameters.groovy
+++ b/pipeline/build/parameters.groovy
@@ -1,5 +1,3 @@
-Map constants = readProperties file: '/etc/jenkins/pipeline_constants.groovy'
-
 List pipelineParameters = [
   string(name: 'GITHUB_ORGANIZATION_NAME',
          defaultValue: constants.GITHUB_ORGANIZATION_NAME,

--- a/pipeline/build/stages.groovy
+++ b/pipeline/build/stages.groovy
@@ -3,7 +3,6 @@
 import groovy.json.*
 import groovy.transform.Field
 
-utils = load 'infrastructure/pipeline/lib/utils.groovy'
 pipelineParameters = load 'infrastructure/pipeline/build/parameters.groovy'
 
 @Field String triggeredRepoName

--- a/pipeline/daily.groovy
+++ b/pipeline/daily.groovy
@@ -1,6 +1,10 @@
 #!groovy
 
+constants = readProperties file: '/etc/jenkins/pipeline_constants.groovy'
+utils = load 'infrastructure/pipeline/lib/utils.groovy'
+
 pipelineStages = load 'infrastructure/pipeline/daily/stages.groovy'
+
 
 def execute() {
   timestamps {

--- a/pipeline/daily/parameters.groovy
+++ b/pipeline/daily/parameters.groovy
@@ -1,6 +1,3 @@
-Map constants = readProperties file: '/etc/jenkins/pipeline_constants.groovy'
-
-List pipelineParameters = load 'infrastructure/pipeline/build/parameters.groovy'
 pipelineParameters += [
   string(name: 'GITHUB_BOT_NAME',
          defaultValue: constants.GITHUB_BOT_NAME,

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -4,8 +4,7 @@ import groovy.transform.Field
 
 buildStages = load 'infrastructure/pipeline/build/stages.groovy'
 pipelineParameters = load 'infrastructure/pipeline/daily/parameters.groovy'
-constants = readProperties file: '/etc/jenkins/pipeline_constants.groovy'
-utils = load 'infrastructure/pipeline/lib/utils.groovy'
+
 
 @Field String PERIODIC_BUILDS_DIR_NAME
 @Field String RELEASE_DATE


### PR DESCRIPTION
We are using the 'load' command at the top level of scripts, which may
cause files to be loaded twice.

This patch moves the loading of common pipeline files (utils,
constants) to the main pipeline file ({daily,build}.groovy) since
these main pipeline files will never load each other.

Pipeline-specific files such as parameters.groovy are loaded in
stages.groovy since the latter might be shared between pipelines.