### PR TITLE
Create a directory for keeping build information in the upload server

### DIFF
--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -28,3 +28,5 @@ pipeline_constants:
   SLACK_TEAM_DOMAIN:
   # Generate at https://my.slack.com/services/new/jenkins-ci
   SLACK_TOKEN:
+
+  BUILD_INFORMATION_DIR: 'info'

--- a/pipeline/build/stages.groovy
+++ b/pipeline/build/stages.groovy
@@ -322,9 +322,10 @@ def uploadArtifacts() {
 
   String jsonString = JsonOutput.prettyPrint(JsonOutput.toJson(buildInfo))
   echo "Writing build status file:\n" + jsonString
-  writeFile file: 'STATUS', text: jsonString
-  utils.archiveAndPrint('STATUS')
-
+  dir(constants.BUILD_INFORMATION_DIR) {
+    writeFile file: 'STATUS', text: jsonString
+    utils.archiveAndPrint('STATUS')
+  }
   if (!buildInfo.BUILD_TIMESTAMP) {
     error('Aborting upload, no timestamp to create the remote directory name')
   }
@@ -348,7 +349,8 @@ gpgcheck=0
   echo 'Uploading artifacts'
   // The --ignore-existing prevents a build from being overwritten if some
   // problem occurs and the build is manually replayed, for example
-  utils.rsyncUpload('--ignore-existing STATUS', BUILD_DIR_RSYNC_URL)
+  utils.rsyncUpload('--ignore-existing --recursive ' +
+      constants.BUILD_INFORMATION_DIR, BUILD_DIR_RSYNC_URL)
   if (buildInfo.BUILD_PACKAGES_FINISHED) {
     utils.rsyncUpload('--ignore-existing --recursive repository',
                       BUILD_DIR_RSYNC_URL)


### PR DESCRIPTION
This allows more information to be added later without having to download and reupload the STATUS file. Later stages of the pipeline may simply drop a .json file in the directory.