### PR TITLE
Reduce number of builds kept by Jenkins

### DIFF
--- a/pipeline/build/stages.groovy
+++ b/pipeline/build/stages.groovy
@@ -12,7 +12,7 @@ pipelineParameters = load 'infrastructure/pipeline/build/parameters.groovy'
 def initialize() {
   properties([parameters(pipelineParameters),
               [$class: 'jenkins.model.BuildDiscarderProperty', strategy:
-               [$class: 'LogRotator', numToKeepStr: '10']]])
+               [$class: 'LogRotator', numToKeepStr: '2']]])
 
   String triggeredRepoURL = scm.userRemoteConfigs.get(0).url
   triggeredRepoName =

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -19,11 +19,12 @@ pipelineParameters = load 'infrastructure/pipeline/daily/parameters.groovy'
 
 def initialize(List pipelineParameters = pipelineParameters,
                String triggerExpression = (
-                 constants.NIGHTLY_BUILDS_CRON_EXPRESSION)) {
+                 constants.NIGHTLY_BUILDS_CRON_EXPRESSION),
+                 numToKeepStr = '7') {
   properties([parameters(pipelineParameters),
               pipelineTriggers([cron(triggerExpression)]),
               [$class: 'jenkins.model.BuildDiscarderProperty', strategy:
-               [$class: 'LogRotator', numToKeepStr: '10']]])
+               [$class: 'LogRotator', numToKeepStr: numToKeepStr]]])
 
   MAIN_REPO_URL_PREFIX = "ssh://git@github.com/$params.GITHUB_ORGANIZATION_NAME"
   PUSH_REPO_URL_PREFIX = "ssh://git@github.com/$params.GITHUB_BOT_USER_NAME"

--- a/pipeline/weekly/stages.groovy
+++ b/pipeline/weekly/stages.groovy
@@ -14,7 +14,8 @@ pipelineParameters = load 'infrastructure/pipeline/weekly/parameters.groovy'
 
 def initialize() {
   String triggerExpression = constants.WEEKLY_BUILDS_CRON_EXPRESSION
-  dailyStages.initialize(pipelineParameters, triggerExpression)
+  String numToKeepStr = '4'
+  dailyStages.initialize(pipelineParameters, triggerExpression, numToKeepStr)
 
   REPOSITORIES_PATH = "$params.BUILDS_WORKSPACE_DIR/repositories"
   UPDATED_VERSIONS_REPO_PATH =


### PR DESCRIPTION
To avoid having space issues in Jenkins master, keep only the last 2
builds for each pull request, the last 7 dailies and last 4 weeklies.