### PR TITLE
Load developer pipeline parameters in weekly pipeline

### DIFF
--- a/pipeline/weekly/stages.groovy
+++ b/pipeline/weekly/stages.groovy
@@ -3,6 +3,7 @@
 import groovy.transform.Field
 
 dailyStages = load 'infrastructure/pipeline/daily/stages.groovy'
+pipelineParameters = load 'infrastructure/pipeline/devel/parameters.groovy'
 pipelineParameters = load 'infrastructure/pipeline/weekly/parameters.groovy'
 
 @Field String REPOSITORIES_PATH


### PR DESCRIPTION
The weekly pipeline was missing some parameters. It will behave like the
developer pipeline, which superseded daily and now has the ".dev" string
in packages releases.

Regression introduced in commit 117288b19bcb76674eb7fbbeef773182578d449f