### PR TITLE
Output pipeline information to a separate file

### DIFF
--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -91,7 +91,7 @@ def createSymlinks() {
 
   File periodicBuildsDir = new File(params.UPLOAD_SERVER_PERIODIC_BUILDS_DIR_PATH)
   File buildDir = new File(params.UPLOAD_SERVER_BUILDS_DIR_PATH,
-                           buildStages.buildInfo.timestamp)
+                           buildStages.buildTimestamp)
   String RELATIVE_BUILD_DIR_PATH =
     periodicBuildsDir.toPath().relativize(buildDir.toPath()).toString()
 


### PR DESCRIPTION
With https://github.com/open-power-host-os/builds/pull/289 we have moved some build data to the files created by the build script. This PR alters what the pipeline (jenkins) outputs to contain only data pertinent to the pipeline itself.