### PR TITLE
Push updates to main versions repository in developer and release pipelines

### DIFF
--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -39,6 +39,10 @@ def execute(Boolean skipIfNoUpdates = false) {
             pipelineStages.uploadBuildArtifacts()
           }
 
+          stage('Commit to Git repository') {
+            pipelineStages.commitToGitRepo()
+          }
+
           stage('Create symlinks') {
             pipelineStages.createSymlinks()
           }


### PR DESCRIPTION
By pushing the updates identified by those pipelines to the repository,
we make sure subsequent builds from them are upgradeable when anything
changes.