### PR TITLE
Copy host keys to known_hosts in master and slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,16 @@ After the SSH proxy is configured, simply use the following to connect to the sy
 
 To automate SSH authentication between 2 hosts, it is necessary to:
  - create an SSH key pair if you still do not have one
- - add the target host to ~/.ssh/known_hosts in the source host. It is also
-   possible to do it by executing a simple SSH command from the source host to
-   the target host. Alternatively, you could disable "StrictHostKeyChecking"
-   for all SSH connections in the source host, but that may be a security hazard.
  - add the SSH private key to ~/.ssh/ in the source host
  - add the SSH public key to ~/.ssh/authorized_keys file in the target host
 
 To be able to upload the results of builds to a server and push commits to
 GitHub automatically, you must automate SSH authentication from Jenkins slaves
-to those two servers. The private SSH key is already installed in Jenkins nodes
+to those two servers. To have this being done automatically at the setup, make sure you have 
+both upload server and GitHub host keys stored in a local `~/.ssh/known_hosts` file. For 
+production servers, it is recommended that you provide a separate file with only 
+those two keys.
+The private SSH key is already installed in Jenkins nodes
 by Jenkins Ansible playbooks, so you do not need to do it manually.
 
 ### Automatically setup Jenkins master and slave(s) using Ansible playbooks

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -43,5 +43,23 @@ to enter the SSH password:
 The `--tags` option tells Ansible to only execute tasks with the specified tag.
 In the previous examples, only tasks with the `setup` tag would be executed.
 
-Provide the data requested by the playbook (eg Jenkins admin user name/password
-and SSH keys locations) and wait automatic setup finish.
+### List of manual input data
+
+Some Ansible playbooks will prompt you to input data to setup Jenkins master and slave nodes.
+
+- `jenkins-master.yaml` playbook
+
+	- Username and password to access Jenkins web UI with administrative privileges. Note that
+a passwordless `jenkins` user will also be created in master and slave nodes.
+	- Paths to SSH private and public keys used to communicate between master and slave nodes.
+
+- `jenkins-slave.yaml` playbook
+
+	- Paths to SSH private and public keys used to communicate between master and slave nodes.
+	- Path to the SSH private key used to upload 
+artifacts to the configured remote server.
+	- Path to the SSH private key used to push commits to GitHub.
+	- Path to the SSH known keys for remote hosts, usually `~/.ssh/known_hosts`. 
+The local file is just copied to remote target.
+
+Provide the data requested by the playbooks and wait automatic setup to finish.

--- a/ansible/jenkins-slave.yaml
+++ b/ansible/jenkins-slave.yaml
@@ -33,3 +33,7 @@
       prompt: "Enter GitHub user's private SSH key file path"
       default: "~/.ssh/open-power-host-os-builds-bot_id_rsa"
       private: no
+    - name: "known_hosts_file_path"
+      prompt: "Enter path to file containing known keys for GitHub and upload server hosts"
+      default: "~/.ssh/known_hosts"
+      private: no

--- a/ansible/roles/builds/tasks/main.yaml
+++ b/ansible/roles/builds/tasks/main.yaml
@@ -29,3 +29,10 @@
     owner={{builder_user_name}} group={{builder_user_name}} mode=0600
   tags:
     - setup
+
+- name: Add known keys for remote hosts
+  copy:
+    src={{known_hosts_file_path}} dest="{{jenkins_home_dir}}/.ssh/known_hosts"
+    owner={{builder_user_name}} group={{builder_user_name}}
+  tags:
+    - setup


### PR DESCRIPTION
Automate host key storage for GitHub and upload server in jenkins nodes.

- Add new task for `ansible/roles/ssh/tasks/main.yaml` that copies a `known_hosts` file containing GitHub's and upload server's host keys from source host to target hosts.

- In `ansible/jenkins_slave.yaml`, prompt the user whether (s)he wants to keep the default file path or provide a new one.