### PR TITLE
Delete builds after their PRs are merged

### DIFF
--- a/jenkins_jobs/build_pipelines.groovy
+++ b/jenkins_jobs/build_pipelines.groovy
@@ -16,6 +16,9 @@ def createPipeline(String repositoryName) {
     triggers {
       periodic(1)
     }
+    orphanedItemStrategy {
+      discardOldItems()
+    }
   }
 }
 


### PR DESCRIPTION
When a pull request was merged, its corresponding build artifacts and
workspaces were still being kept in the Jenkins master and slaves,
respectively. From now on, they will be deleted immediately
after the corresponding pull request is merged.