### PR TITLE
Fix build-release notes --info-files-dir parameter

### DIFF
--- a/pipeline/weekly/stages.groovy
+++ b/pipeline/weekly/stages.groovy
@@ -55,7 +55,7 @@ python host_os.py \
        --verbose \
        --work-dir $params.BUILDS_WORKSPACE_DIR \
        build-release-notes \
-           --info-files-dir '../../repository' \
+           --info-files-dir '../../build-packages/repository' \
            --release-notes-repo-url $GITHUB_IO_MAIN_REPO_URL \
            --updater-name '$params.GITHUB_BOT_NAME' \
            --updater-email $params.GITHUB_BOT_EMAIL \


### PR DESCRIPTION
The path added in commit c8bc199ecbbe94eb1c81e2089d9fe2e15ac65c60
was incorrect.