### PR TITLE
Parameterize Github URL at infrastructure setup

### DIFF
--- a/ansible/roles/builds/templates/github_ssh_config.j2
+++ b/ansible/roles/builds/templates/github_ssh_config.j2
@@ -1,4 +1,4 @@
-host github.com
- HostName github.com
+host github
+ HostName {{pipeline_constants.GITHUB_DOMAIN}}
  IdentityFile "{{builder_home_dir}}/.ssh/github_id_rsa"
  User git

--- a/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
+++ b/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
@@ -13,7 +13,7 @@
         <hudson.model.StringParameterDefinition>
           <name>REPOSITORY_URL</name>
           <description>Repository to download the DSL job descriptors.</description>
-          <defaultValue>ssh://git@github.com/{{pipeline_constants.GITHUB_ORGANIZATION_NAME}}/infrastructure.git</defaultValue>
+          <defaultValue>ssh://git@github/{{pipeline_constants.GITHUB_ORGANIZATION_NAME}}/infrastructure.git</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>REPOSITORY_COMMIT</name>

--- a/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
+++ b/ansible/roles/jenkins-seed-job/templates/seed_job_config.xml.j2
@@ -13,7 +13,7 @@
         <hudson.model.StringParameterDefinition>
           <name>REPOSITORY_URL</name>
           <description>Repository to download the DSL job descriptors.</description>
-          <defaultValue>https://github.com/{{pipeline_constants.GITHUB_ORGANIZATION_NAME}}/infrastructure.git</defaultValue>
+          <defaultValue>ssh://git@github.com/{{pipeline_constants.GITHUB_ORGANIZATION_NAME}}/infrastructure.git</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>REPOSITORY_COMMIT</name>

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -1,5 +1,6 @@
 ---
 pipeline_constants:
+  GITHUB_DOMAIN: github.com
   GITHUB_ORGANIZATION_NAME:
   GITHUB_BOT_NAME:
   GITHUB_BOT_USER_NAME:

--- a/jenkins_jobs/build_old_host_os_versions.groovy
+++ b/jenkins_jobs/build_old_host_os_versions.groovy
@@ -5,7 +5,7 @@ job('build_old_host_os_versions') {
 		"${GITHUB_ORGANIZATION_NAME}",
 		'GitHub organization from where the Host OS repositories will be checked out.')
     stringParam('BUILDS_REPO_URL',
-		"https://github.com/${GITHUB_ORGANIZATION_NAME}/builds.git",
+		"ssh://git@github.com/${GITHUB_ORGANIZATION_NAME}/builds.git",
 		'URL of the builds repository.')
     stringParam('BUILDS_REPO_REFERENCE', 'origin/master',
 		'Git reference to checkout from the builds repository.')

--- a/jenkins_jobs/build_old_host_os_versions.groovy
+++ b/jenkins_jobs/build_old_host_os_versions.groovy
@@ -5,7 +5,7 @@ job('build_old_host_os_versions') {
 		"${GITHUB_ORGANIZATION_NAME}",
 		'GitHub organization from where the Host OS repositories will be checked out.')
     stringParam('BUILDS_REPO_URL',
-		"ssh://git@github.com/${GITHUB_ORGANIZATION_NAME}/builds.git",
+		"ssh://git@github/${GITHUB_ORGANIZATION_NAME}/builds.git",
 		'URL of the builds repository.')
     stringParam('BUILDS_REPO_REFERENCE', 'origin/master',
 		'Git reference to checkout from the builds repository.')

--- a/jenkins_jobs/build_old_host_os_versions/script.sh
+++ b/jenkins_jobs/build_old_host_os_versions/script.sh
@@ -4,7 +4,7 @@ LEGACY_MOCK_CONFIG_FILE="${LEGACY_MOCK_DIR}/centOS-7.2-ppc64le.cfg"
 BUILD_CONFIG_FILE="config/host_os.yaml"
 CENTOS_7_YUM_REPO_URL="http://mirror.centos.org/altarch/7"
 CENTOS_7_2_YUM_REPO_URL="http://vault.centos.org/altarch/7.2.1511"
-VERSIONS_REPO_URL="https://github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
+VERSIONS_REPO_URL="ssh://git@github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
 TAG_1_0="hostos-1.0"
 TAG_1_5="hostos-1.5"
 

--- a/jenkins_jobs/build_old_host_os_versions/script.sh
+++ b/jenkins_jobs/build_old_host_os_versions/script.sh
@@ -4,7 +4,7 @@ LEGACY_MOCK_CONFIG_FILE="${LEGACY_MOCK_DIR}/centOS-7.2-ppc64le.cfg"
 BUILD_CONFIG_FILE="config/host_os.yaml"
 CENTOS_7_YUM_REPO_URL="http://mirror.centos.org/altarch/7"
 CENTOS_7_2_YUM_REPO_URL="http://vault.centos.org/altarch/7.2.1511"
-VERSIONS_REPO_URL="ssh://git@github.com/${GITHUB_ORGANIZATION_NAME}/versions.git"
+VERSIONS_REPO_URL="ssh://git@github/${GITHUB_ORGANIZATION_NAME}/versions.git"
 TAG_1_0="hostos-1.0"
 TAG_1_5="hostos-1.5"
 

--- a/jenkins_jobs/periodic_pipelines.groovy
+++ b/jenkins_jobs/periodic_pipelines.groovy
@@ -5,7 +5,7 @@ def createPeriodicPipeline(String name, String cronExpression) {
         script("""\
 node('master') {
   dir('infrastructure') {
-    git(url: 'ssh://git@github.com/$GITHUB_ORGANIZATION_NAME/infrastructure.git',
+    git(url: 'ssh://git@github/$GITHUB_ORGANIZATION_NAME/infrastructure.git',
         branch: '$REPOSITORY_COMMIT')
   }
   pipeline = load 'infrastructure/pipeline/${name}.groovy'

--- a/jenkins_jobs/periodic_pipelines.groovy
+++ b/jenkins_jobs/periodic_pipelines.groovy
@@ -5,7 +5,7 @@ def createPeriodicPipeline(String name, String cronExpression) {
         script("""\
 node('master') {
   dir('infrastructure') {
-    git(url: 'https://github.com/$GITHUB_ORGANIZATION_NAME/infrastructure.git',
+    git(url: 'ssh://git@github.com/$GITHUB_ORGANIZATION_NAME/infrastructure.git',
         branch: '$REPOSITORY_COMMIT')
   }
   pipeline = load 'infrastructure/pipeline/${name}.groovy'

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -137,7 +137,7 @@ python host_os.py \
 
 def commitToGitRepo() {
   String GITHUB_BOT_HTTP_URL =
-    "https://github.com/$params.GITHUB_BOT_USER_NAME"
+    "ssh://git@github.com/$params.GITHUB_BOT_USER_NAME"
   String VERSIONS_BRANCH_HTTP_URL = (
     "$GITHUB_BOT_HTTP_URL/$VERSIONS_REPO_NAME/commit/" +
     "$COMMIT_BRANCH")

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -34,8 +34,8 @@ def initialize(Map pipelineParameters = pipelineParameters,
               [$class: 'jenkins.model.BuildDiscarderProperty', strategy:
                [$class: 'LogRotator', numToKeepStr: numToKeepStr]]])
 
-  MAIN_REPO_URL_PREFIX = "ssh://git@github.com/$params.GITHUB_ORGANIZATION_NAME"
-  PUSH_REPO_URL_PREFIX = "ssh://git@github.com/$params.GITHUB_BOT_USER_NAME"
+  MAIN_REPO_URL_PREFIX = "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME"
+  PUSH_REPO_URL_PREFIX = "ssh://git@github/$params.GITHUB_BOT_USER_NAME"
 
   String REPOSITORIES_PATH = "$params.BUILDS_WORKSPACE_DIR/repositories"
 
@@ -70,7 +70,7 @@ def initialize(Map pipelineParameters = pipelineParameters,
 def updateVersions() {
   deleteDir()
   dir('builds') {
-    git(url: "ssh://git@github.com/$params.GITHUB_ORGANIZATION_NAME/builds.git",
+    git(url: "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME/builds.git",
         branch: params.BUILDS_REPO_REFERENCE)
     exitCode = sh(script: """\
 python host_os.py    \
@@ -115,7 +115,7 @@ def createReleaseNotes(String releaseCategory) {
   deleteDir()
   unstash 'repository_dir'
   dir('builds') {
-    git(url: "ssh://git@github.com/$params.GITHUB_ORGANIZATION_NAME/builds.git",
+    git(url: "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME/builds.git",
         branch: params.BUILDS_REPO_REFERENCE)
     sh """\
 python host_os.py \
@@ -137,7 +137,7 @@ python host_os.py \
 
 def commitToGitRepo() {
   String GITHUB_BOT_HTTP_URL =
-    "ssh://git@github.com/$params.GITHUB_BOT_USER_NAME"
+    "ssh://git@github/$params.GITHUB_BOT_USER_NAME"
   String VERSIONS_BRANCH_HTTP_URL = (
     "$GITHUB_BOT_HTTP_URL/$VERSIONS_REPO_NAME/commit/" +
     "$COMMIT_BRANCH")

--- a/pipeline/lib/utils.groovy
+++ b/pipeline/lib/utils.groovy
@@ -39,7 +39,7 @@ def getCredentialsStore() {
 }
 
 def getGitRepos(String triggeredRepoName) {
-  String githubOrgPath = "ssh://git@github.com/$params.GITHUB_ORGANIZATION_NAME"
+  String githubOrgPath = "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME"
   gitRepos = [:]
   for (String repoName : ['builds', 'versions']) {
     if (repoName == triggeredRepoName) {


### PR DESCRIPTION
Instead of having GitHub host name (github.com) hard-coded at the setup, now replace it with `$GIT_REPOS_BASE_URL` so it allows users to use enterprise instances of GitHub as well (github.ibm.com, for example). 

