### PR TITLE
Stop overwriting ssh config file on target host

### DIFF
--- a/ansible/roles/builds/tasks/main.yaml
+++ b/ansible/roles/builds/tasks/main.yaml
@@ -23,10 +23,13 @@
     - setup
 
 - name: Configure SSH to push to GitHub repository
-  template:
-    src=github_ssh_config.j2
-    dest="{{builder_home_dir}}/.ssh/config"
-    owner={{builder_user_name}} group={{builder_user_name}} mode=0600
+  blockinfile:
+    path: "{{builder_home_dir}}/.ssh/config"
+    block: "{{ lookup('template', 'github_ssh_config.j2') }}"
+    create: yes
+    owner: "{{builder_user_name}}"
+    group: "{{builder_user_name}}"
+    mode: 0600
   tags:
     - setup
 


### PR DESCRIPTION
Users may have other entries in their `~/.ssh/config` file that are not related to Ansible. It is not interesting to have them being overwritten by the playbooks in the target host.

The `template` module now has been replaced by `blockinfile` module, which appends the content of `github_ssh_config.j2` to the end of `~/.ssh/config` (if not already there).  If the file doesn't exist in the target host, it will create a new one. 

The `blockinfile` appends the text block surrounded by customizable marker lines.