### PR TITLE
Parametrize jenkins user name

### DIFF
--- a/ansible/roles/builds/tasks/main.yaml
+++ b/ansible/roles/builds/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Create Host OS build directories
   file:
     name={{pipeline_constants.BUILDS_WORKSPACE_DIR}} state=directory
-    owner={{builder_user_name}} group=mock
+    owner={{user_name}} group=mock
   tags:
     - setup
 
@@ -10,7 +10,7 @@
   copy:
     src={{upload_server_user_private_ssh_key_file_path}}
     dest="{{builder_home_dir}}/.ssh/upload_server_id_rsa"
-    owner={{builder_user_name}} group={{builder_user_name}} mode=0600
+    owner={{user_name}} group={{user_name}} mode=0600
   tags:
     - setup
 
@@ -18,7 +18,7 @@
   copy:
     src={{github_user_private_ssh_key_file_path}}
     dest="{{builder_home_dir}}/.ssh/github_id_rsa"
-    owner={{builder_user_name}} group={{builder_user_name}} mode=0600
+    owner={{user_name}} group={{user_name}} mode=0600
   tags:
     - setup
 
@@ -27,8 +27,8 @@
     path: "{{builder_home_dir}}/.ssh/config"
     block: "{{ lookup('template', 'github_ssh_config.j2') }}"
     create: yes
-    owner: "{{builder_user_name}}"
-    group: "{{builder_user_name}}"
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: 0600
   tags:
     - setup
@@ -36,6 +36,6 @@
 - name: Add known keys for remote hosts
   copy:
     src={{known_hosts_file_path}} dest="{{jenkins_home_dir}}/.ssh/known_hosts"
-    owner={{builder_user_name}} group={{builder_user_name}}
+    owner={{user_name}} group={{user_name}}
   tags:
     - setup

--- a/ansible/roles/jenkins-master/tasks/main.yaml
+++ b/ansible/roles/jenkins-master/tasks/main.yaml
@@ -4,16 +4,16 @@
     name={{item.name}} owner={{item.owner}} group={{item.group}}
     mode={{item.mode}} state=directory
   with_items:
-    - { name: "{{jenkins_bin_dir}}/bin", owner: jenkins, group: jenkins,
+    - { name: "{{jenkins_bin_dir}}/bin", owner: "{{user_name}}", group: "{{user_name}}",
         mode: "0755" }
-    - { name: /var/log/jenkins, owner: jenkins, group: jenkins, mode: "0755" }
+    - { name: /var/log/jenkins, owner: "{{user_name}}", group: "{{user_name}}", mode: "0755" }
   tags:
     - setup
 
 - name: Install {{jenkins_bin_dir}}/bin/jenkinsd
   template:
     src=jenkinsd dest="{{jenkins_bin_dir}}/bin/jenkinsd"
-    owner=jenkins group=root mode=0755
+    owner={{user_name}} group=root mode=0755
   notify: restart jenkins
   tags:
     - setup
@@ -45,7 +45,7 @@
 
 - name: Ensure jenkins.war permissions
   file:
-    path="{{jenkins_bin_dir}}/jenkins.war" owner=jenkins group=root mode=0644
+    path="{{jenkins_bin_dir}}/jenkins.war" owner={{user_name}} group=root mode=0644
   when: jenkinswar.changed
   notify: restart jenkins
   tags:
@@ -73,7 +73,7 @@
 - name: Create Jenkins admin user directory
   file:
     path="{{jenkins_home_dir}}/users/{{jenkins_admin_user}}"
-    owner=jenkins group=jenkins mode=0755 state=directory recurse=yes
+    owner={{user_name}} group={{user_name}} mode=0755 state=directory recurse=yes
   tags:
     - setup
 

--- a/ansible/roles/jenkins-master/tasks/main.yaml
+++ b/ansible/roles/jenkins-master/tasks/main.yaml
@@ -13,7 +13,7 @@
 - name: Install {{jenkins_bin_dir}}/bin/jenkinsd
   template:
     src=jenkinsd dest="{{jenkins_bin_dir}}/bin/jenkinsd"
-    owner={{user_name}} group=root mode=0755
+    owner=root group=root mode=0755
   notify: restart jenkins
   tags:
     - setup
@@ -22,6 +22,7 @@
   get_url:
     url=http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war.sha256
     dest="{{jenkins_bin_dir}}/jenkins.war.sha256"
+    owner=root group=root
     force=yes
   tags:
     - setup
@@ -36,6 +37,7 @@
   get_url:
     url=http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war
     dest="{{jenkins_bin_dir}}/jenkins.war"
+    owner=root group=root
     timeout=30
     checksum="sha256:{{jenkins_war_sha256.stdout}}"
   register: jenkinswar
@@ -45,7 +47,7 @@
 
 - name: Ensure jenkins.war permissions
   file:
-    path="{{jenkins_bin_dir}}/jenkins.war" owner={{user_name}} group=root mode=0644
+    path="{{jenkins_bin_dir}}/jenkins.war" owner=root group=root mode=0644
   when: jenkinswar.changed
   notify: restart jenkins
   tags:
@@ -81,12 +83,15 @@
   template:
     src=admin_config.xml.j2 dest="{{jenkins_home_dir}}/users/{{jenkins_admin_user}}/config.xml"
     force=no
+    owner={{user_name}} group={{user_name}}
   register: jenkins_admin_config
   tags:
     - setup
 
 - name: Create Jenkins config
-  copy: src=config.xml dest="{{jenkins_home_dir}}/config.xml"
+  copy:
+    src=config.xml dest="{{jenkins_home_dir}}/config.xml"
+    owner={{user_name}} group={{user_name}}
   register: jenkins_config
   tags:
     - setup
@@ -95,6 +100,8 @@
   template:
     src: jenkins.model.JenkinsLocationConfiguration.xml.j2
     dest: "{{jenkins_home_dir}}/jenkins.model.JenkinsLocationConfiguration.xml"
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
   register: jenkins_url_config
   tags:
     - setup

--- a/ansible/roles/jenkins-pipeline/tasks/main.yaml
+++ b/ansible/roles/jenkins-pipeline/tasks/main.yaml
@@ -11,6 +11,7 @@
     src: pipeline_constants.groovy.j2
     dest: "{{jenkins_config_dir}}/pipeline_constants.groovy"
     owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0444"
   tags:
     - setup
@@ -75,6 +76,7 @@
     src: scriptApproval.xml.j2
     dest: "{{jenkins_home_dir}}/scriptApproval.xml"
     owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:

--- a/ansible/roles/jenkins-pipeline/tasks/main.yaml
+++ b/ansible/roles/jenkins-pipeline/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create Jenkins configuration directory
   file:
-    name="{{jenkins_config_dir}}" owner=jenkins group=jenkins
+    name="{{jenkins_config_dir}}" owner={{user_name}} group={{user_name}}
     mode="0755" state=directory
   tags:
     - setup
@@ -10,7 +10,7 @@
   template:
     src: pipeline_constants.groovy.j2
     dest: "{{jenkins_config_dir}}/pipeline_constants.groovy"
-    owner: jenkins
+    owner: "{{user_name}}"
     mode: "0444"
   tags:
     - setup
@@ -19,8 +19,8 @@
   template:
     src: org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml.j2
     dest: "{{jenkins_home_dir}}/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:
@@ -30,8 +30,8 @@
   file:
     state: directory
     dest: "{{credentials_job_target_dir}}"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0755"
   notify: restart jenkins
   tags:
@@ -41,8 +41,8 @@
   template:
     src: "{{credentials_job_template}}"
     dest: "{{credentials_job_target_dir}}/config.xml"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:
@@ -52,8 +52,8 @@
   file:
     state: directory
     dest: "{{slave_node_job_target_dir}}"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0755"
   notify: restart jenkins
   tags:
@@ -63,8 +63,8 @@
   template:
     src: "{{slave_node_job_template}}"
     dest: "{{slave_node_job_target_dir}}/config.xml"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:
@@ -74,7 +74,7 @@
   template:
     src: scriptApproval.xml.j2
     dest: "{{jenkins_home_dir}}/scriptApproval.xml"
-    owner: jenkins
+    owner: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:

--- a/ansible/roles/jenkins-pipeline/templates/create_credentials_config.xml.j2
+++ b/ansible/roles/jenkins-pipeline/templates/create_credentials_config.xml.j2
@@ -28,7 +28,7 @@
         <hudson.model.StringParameterDefinition>
           <name>JENKINS_SLAVE_USER_NAME</name>
           <description>User name used to access Jenkins slaves.</description>
-          <defaultValue>jenkins</defaultValue>
+          <defaultValue>{{jenkins_slave_user_name}}</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>JENKINS_SLAVE_PRIVATE_SSH_KEY_PATH</name>

--- a/ansible/roles/jenkins-pipeline/templates/create_slave_node_config.xml.j2
+++ b/ansible/roles/jenkins-pipeline/templates/create_slave_node_config.xml.j2
@@ -29,7 +29,7 @@
         <hudson.model.StringParameterDefinition>
           <name>NODE_USER_HOME</name>
           <description>Path to the user`s home directory in the slave node.</description>
-          <defaultValue>/home/jenkins/</defaultValue>
+          <defaultValue>/home/{{jenkins_slave_user_name}}/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>NUMBER_OF_EXECUTORS</name>

--- a/ansible/roles/jenkins-seed-job/tasks/main.yaml
+++ b/ansible/roles/jenkins-seed-job/tasks/main.yaml
@@ -11,8 +11,8 @@
   file:
     state: directory
     dest: "{{seed_job_target_dir}}"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0755"
   notify: restart jenkins
   tags:
@@ -22,8 +22,8 @@
   template:
     src: "{{seed_job_template}}"
     dest: "{{seed_job_target_dir}}/config.xml"
-    owner: jenkins
-    group: jenkins
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
     mode: "0644"
   notify: restart jenkins
   tags:

--- a/ansible/roles/jenkins-seed-job/tasks/main.yaml
+++ b/ansible/roles/jenkins-seed-job/tasks/main.yaml
@@ -3,6 +3,8 @@
   copy:
     src: javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml
     dest: "{{jenkins_home_dir}}/javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml"
+    owner: "{{user_name}}"
+    group: "{{user_name}}"
   notify: restart jenkins
   tags:
     - setup

--- a/ansible/roles/nginx/tasks/main.yaml
+++ b/ansible/roles/nginx/tasks/main.yaml
@@ -21,6 +21,7 @@
     -keyout {{nginx_ssl_certificate_key}}
     -out {{nginx_ssl_certificate}}
     creates="{{nginx_ssl_certificate}}"
+    owner=root group=root
   tags:
     - setup
 

--- a/ansible/roles/ssh/tasks/main.yaml
+++ b/ansible/roles/ssh/tasks/main.yaml
@@ -4,7 +4,7 @@
     name={{item.name}} owner={{item.owner}} group={{item.group}}
     mode={{item.mode}} state=directory
   with_items:
-    - { name: "{{jenkins_home_dir}}/.ssh", owner: jenkins, group: jenkins,
+    - { name: "{{jenkins_home_dir}}/.ssh", owner: "{{user_name}}", group: "{{user_name}}",
         mode: "0700" }
   tags:
     - setup
@@ -18,9 +18,9 @@
   with_items:
     - { src: "{{jenkins_private_ssh_key_file_path}}",
         dest: "{{jenkins_home_dir}}/.ssh/jenkins_id_rsa",
-        owner: jenkins, group: jenkins, mode: "0600" }
+        owner: "{{user_name}}", group: "{{user_name}}", mode: "0600" }
     - { src: "{{jenkins_public_ssh_key_file_path}}",
         dest: "{{jenkins_home_dir}}/.ssh/authorized_keys",
-        owner: jenkins, group: jenkins, mode: "0600" }
+        owner: "{{user_name}}", group: "{{user_name}}", mode: "0600" }
   tags:
     - setup

--- a/ansible/roles/systemd/templates/jenkins.service
+++ b/ansible/roles/systemd/templates/jenkins.service
@@ -9,7 +9,7 @@ Description=Jenkins Daemon
 [Service]
 Type=forking
 ExecStart={{jenkins_bin_dir}}/bin/jenkinsd
-User=jenkins
+User={{user_name}}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/user/tasks/main.yaml
+++ b/ansible/roles/user/tasks/main.yaml
@@ -1,12 +1,12 @@
 ---
 - name: Create Jenkins group
-  group: name=jenkins state=present
+  group: name={{user_name}} state=present
   tags:
     - setup
 
 - name: Create Jenkins user
   user:
-    name=jenkins group=jenkins groups={{user_groups}} comment="Jenkins User"
+    name={{user_name}} group={{user_name}} groups={{user_groups}} comment="Jenkins User"
     home="{{jenkins_home_dir}}" state=present
   tags:
     - setup

--- a/ansible/vars-master.yaml
+++ b/ansible/vars-master.yaml
@@ -1,6 +1,7 @@
 ---
 user_groups:
 
+user_name: jenkins-master
 nginx_jenkins_access_log: /var/log/nginx/jenkins.access.log
 
 jenkins_home_dir: /var/lib/jenkins

--- a/ansible/vars-slave.yaml
+++ b/ansible/vars-slave.yaml
@@ -1,6 +1,6 @@
 ---
-builder_user_name: jenkins
-builder_home_dir: "/home/{{builder_user_name}}"
+user_name: "{{jenkins_slave_user_name}}"
+builder_home_dir: "/home/{{user_name}}"
 user_groups: mock
 
-jenkins_home_dir: /home/jenkins
+jenkins_home_dir: "/home/{{user_name}}"

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -1,5 +1,6 @@
 ---
 github_domain: github.com
+jenkins_slave_user_name: jenkins-slave
 
 pipeline_constants:
   GITHUB_ORGANIZATION_NAME:


### PR DESCRIPTION
Now jenkins master and slave nodes have their own `jenkins-master` and `jenkins-slave` usernames, respectively. 

Note: The job "Create slave node" is performed by master, but it uses the name of the slave node's home directory. Therefore, it needs to have access to slave node's username, hence the `jenkins_slave_user_name` variable added to `vars.yaml`.