### PR TITLE
Fix packages information in release notes

### DIFF
--- a/ansible/roles/jenkins-master/defaults/main.yaml
+++ b/ansible/roles/jenkins-master/defaults/main.yaml
@@ -4,7 +4,7 @@ java_initial_heap_size: "512M"
 java_max_heap_size: "1024M"
 java_debug: "5"
 
-jenkins_url: "https://{{ansible_hostname}}/"
+jenkins_url: "https://{{ansible_fqdn}}/"
 jenkins_log_file: "/var/log/jenkins/jenkins.log"
 jenkins_plugins:
   # Checkout git repositories

--- a/pipeline/build/parameters.groovy
+++ b/pipeline/build/parameters.groovy
@@ -58,6 +58,12 @@ Map pipelineParameters = [
   PACKAGES: [
     defaultValue: '',
     description: 'Packages to build. Leave empty to build all.'],
+  HOST_OS_EXTRA_PARAMETERS: [
+    defaultValue: '',
+    description: 'Arbitrary extra parameters to pass to the ' +
+      'host_os.py script, coming before the subcommands. Arguments ' +
+      'containing spaces have to be enclosed in double quotes, e.g. ' +
+      '--mock-args "--with tests"'],
   BUILD_PACKAGES_EXTRA_PARAMETERS: [
     defaultValue: '',
     description: 'Arbitrary extra parameters to pass to the ' +

--- a/pipeline/build/stages.groovy
+++ b/pipeline/build/stages.groovy
@@ -109,7 +109,7 @@ def validate() {
   }
 }
 
-def buildPackages() {
+def buildPackages(boolean cleanWorkspace = true) {
   if (triggeredRepoName) {
     utils.setGithubStatus(
       triggeredRepoName, 'Building packages', 'PENDING')
@@ -123,7 +123,9 @@ def buildPackages() {
   String VERSIONS_REPO_PATH =
     "$params.BUILDS_WORKSPACE_DIR/repositories/$VERSIONS_REPO_DIR"
 
-  deleteDir()
+  if (cleanWorkspace) {
+    deleteDir()
+  }
   utils.checkoutRepo('builds', gitRepos)
   dir('builds') {
     // Tell mock to use a different mirror/repo.
@@ -196,7 +198,7 @@ python host_os.py \\
   }
 }
 
-def buildIso() {
+def buildIso(boolean cleanWorkspace = true) {
   if (!buildInfo.build_packages_finished) {
     error('Skipping ISO build because packages build failed')
   }
@@ -215,7 +217,9 @@ def buildIso() {
   ISO_VERSION = ISO_VERSION.replaceAll(/:/, '')
   ISO_VERSION = ISO_VERSION.replaceFirst(/[.].*/, '')
 
-  deleteDir()
+  if (cleanWorkspace) {
+    deleteDir()
+  }
   utils.checkoutRepo('builds', gitRepos)
 
   unstash 'repository_dir'
@@ -274,13 +278,15 @@ python host_os.py \\
   }
 }
 
-def uploadArtifacts() {
+def uploadArtifacts(boolean cleanWorkspace = true) {
   if (triggeredRepoName) {
     utils.setGithubStatus(
       triggeredRepoName, 'Uploading artifacts', 'PENDING')
   }
 
-  deleteDir()
+  if (cleanWorkspace) {
+    deleteDir()
+  }
   if (buildInfo.build_packages_finished) {
     unstash 'repository_dir'
 
@@ -336,21 +342,30 @@ gpgcheck=0
   utils.archiveAndPrint('hostos.repo')
 
   echo 'Creating remote build directory hierarchy'
-  sh "mkdir -p $BUILDS_DIR_NAME/$buildTimestamp"
-  utils.rsyncUpload("--recursive $BUILDS_DIR_NAME/", BUILDS_DIR_RSYNC_URL)
+  // This avoids conflicts if the remote builds dir is named the same as
+  // other directories
+  dir('remote_dirs') {
+    sh "mkdir -p $BUILDS_DIR_NAME/$buildTimestamp"
+    utils.rsyncUpload("--recursive $BUILDS_DIR_NAME/", BUILDS_DIR_RSYNC_URL)
+  }
 
   echo 'Uploading artifacts'
   // The --ignore-existing prevents a build from being overwritten if some
-  // problem occurs and the build is manually replayed, for example
+  // problem occurs and the build is manually replayed, for example.
+  // When called from periodic builds, the workspace is not cleaned and
+  // the repository and iso directories are still symlinks, so we need the
+  // --copy-dirlinks flag.
   utils.rsyncUpload('--ignore-existing --recursive ' +
       constants.BUILD_INFORMATION_DIR, BUILD_DIR_RSYNC_URL)
   if (buildInfo.build_packages_finished) {
-    utils.rsyncUpload('--ignore-existing --recursive repository',
-                      BUILD_DIR_RSYNC_URL)
+    utils.rsyncUpload(
+      '--ignore-existing --copy-dirlinks --recursive repository',
+      BUILD_DIR_RSYNC_URL)
     utils.rsyncUpload('hostos.repo', BUILD_DIR_RSYNC_URL)
   }
   if (buildInfo.build_iso_finished) {
-    utils.rsyncUpload('--ignore-existing --recursive iso', BUILD_DIR_RSYNC_URL)
+    utils.rsyncUpload(
+      '--ignore-existing --copy-dirlinks --recursive iso', BUILD_DIR_RSYNC_URL)
   }
 }
 

--- a/pipeline/build/stages.groovy
+++ b/pipeline/build/stages.groovy
@@ -158,6 +158,7 @@ def buildPackages() {
         sh """\
 python host_os.py \\
        --work-dir $params.BUILDS_WORKSPACE_DIR \\
+       $params.HOST_OS_EXTRA_PARAMETERS \\
        build-packages \\
            --force-rebuild \\
            --keep-build-dir \\
@@ -246,6 +247,7 @@ def buildIso() {
       catchError {
         sh """\
 python host_os.py \\
+       $params.HOST_OS_EXTRA_PARAMETERS \\
        build-iso \\
            --packages-dir ../repository \\
            --iso-version $ISO_VERSION \\

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -136,22 +136,21 @@ python host_os.py    \
 }
 
 def buildPackages() {
-  buildStages.buildPackages()
+  buildStages.buildPackages(false)
 }
 
 def buildIso() {
-  buildStages.buildIso()
+  buildStages.buildIso(false)
 }
 
 def uploadBuildArtifacts() {
-  buildStages.uploadArtifacts()
+  buildStages.uploadArtifacts(false)
   if (currentBuild.result == 'FAILURE') {
     error('Build failed, aborting')
   }
 }
 
 def createReleaseNotes(String releaseCategory) {
-  deleteDir()
   unstash 'repository_dir'
   dir('builds') {
     git(url: "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME/builds.git",

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -79,6 +79,10 @@ def updateVersions() {
   dir('builds') {
     git(url: "ssh://git@github/$params.GITHUB_ORGANIZATION_NAME/builds.git",
         branch: params.BUILDS_REPO_REFERENCE)
+    String packagesParameter = ''
+    if (params.PACKAGES) {
+      packagesParameter = "--packages $PACKAGES"
+    }
     exitCode = sh(script: """\
 python host_os.py    \
        --verbose \
@@ -91,6 +95,7 @@ python host_os.py    \
            --push-repo-url $VERSIONS_PUSH_REPO_URL \
            --push-repo-branch $COMMIT_BRANCH \
            --commit-message '$COMMIT_MESSAGE' \
+           $packagesParameter
 """, returnStatus: true)
 
     Integer SUCCESS_EXIT_CODE = 0

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -87,6 +87,7 @@ def updateVersions() {
 python host_os.py    \
        --verbose \
        --work-dir $params.BUILDS_WORKSPACE_DIR \
+       $params.HOST_OS_EXTRA_PARAMETERS \
        update-versions \
            --packages-metadata-repo-url $VERSIONS_MAIN_REPO_URL \
            --packages-metadata-repo-branch $params.VERSIONS_REPO_REFERENCE \
@@ -159,6 +160,7 @@ def createReleaseNotes(String releaseCategory) {
 python host_os.py \
        --verbose \
        --work-dir $params.BUILDS_WORKSPACE_DIR \
+       $params.HOST_OS_EXTRA_PARAMETERS \
        build-release-notes \
            --info-files-dir '../repository' \
            --release-notes-repo-url $GITHUB_IO_MAIN_REPO_URL \

--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -17,7 +17,7 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
       node('builds_slave_label') {
         lock(resource: "update-versions_workspace_$env.NODE_NAME") {
           stage('Update packages versions') {
-            pipelineStages.updateVersions()
+            pipelineStages.updateVersions(releaseCategory)
           }
 
           if (skipIfNoUpdates && !pipelineStages.hasUpdates) {

--- a/pipeline/devel/parameters.groovy
+++ b/pipeline/devel/parameters.groovy
@@ -34,11 +34,12 @@ pipelineParameters += [
     description:
       'Access token from the Jenkins integration app in Slack. ' +
       'More info at: https://my.slack.com/services/new/jenkins-ci'],
-  BUILD_PACKAGES_EXTRA_PARAMETERS: [
-    defaultValue: '--mock-args "--define \'extraver .dev\'"',
-    description: 'Arbitrary extra parameters to pass to the build-packages ' +
-      'command. Arguments containing spaces have to be enclosed in double ' +
-      'quotes, e.g. --mock-args "--with tests"'],
+  HOST_OS_EXTRA_PARAMETERS: [
+    defaultValue: '--config-file ../host_os.yaml',
+    description: 'Arbitrary extra parameters to pass to the ' +
+      'host_os.py script, coming before the subcommands. Arguments ' +
+      'containing spaces have to be enclosed in double quotes, e.g. ' +
+      '--mock-args "--with tests"'],
 ]
 
 return pipelineParameters

--- a/pipeline/lib/utils.groovy
+++ b/pipeline/lib/utils.groovy
@@ -76,7 +76,7 @@ def checkoutRepo(String repoName, Map gitRepos) {
 
 def replaceInFile(String fileName, String token, String value) {
   String content = readFile fileName
-  content.replaceAll(token, value)
+  content = content.replaceAll(token, value)
   writeFile file: fileName, text: content
 }
 

--- a/pipeline/release/parameters.groovy
+++ b/pipeline/release/parameters.groovy
@@ -6,11 +6,6 @@ pipelineParameters += [
   VERSIONS_REPO_REFERENCE: [
     defaultValue: 'hostos-release',
     description: 'Git reference to checkout from the versions repository.'],
-  BUILD_PACKAGES_EXTRA_PARAMETERS: [
-    defaultValue: '--mock-args "--define \'extraver .rel\'"',
-    description: 'Arbitrary extra parameters to pass to the build-packages ' +
-      'command. Arguments containing spaces have to be enclosed in double ' +
-      'quotes, e.g. --mock-args "--with tests"'],
 ]
 
 return pipelineParameters


### PR DESCRIPTION
The release field was incorrectly filled in packages.json, causing the release notes to contain wrong information.

Some other fixes and improvements in pipeline that allowed testing of this issue.

Depends on https://github.com/open-power-host-os/builds/pull/301