### PR TITLE
Rename build-iso to build-images

### DIFF
--- a/pipeline/build.groovy
+++ b/pipeline/build.groovy
@@ -31,9 +31,9 @@ def execute() {
     }
 
     catchError {
-      stage('Build ISO') {
+      stage('Build images') {
         node('builds_slave_label') {
-          pipelineStages.buildIso()
+          pipelineStages.buildImages()
         }
       }
     }

--- a/pipeline/build/parameters.groovy
+++ b/pipeline/build/parameters.groovy
@@ -69,10 +69,10 @@ Map pipelineParameters = [
     description: 'Arbitrary extra parameters to pass to the ' +
       'build-packages command. Arguments containing spaces have to ' +
       'be enclosed in double quotes, e.g. --mock-args "--with tests"'],
-  BUILD_ISO_EXTRA_PARAMETERS: [
+  BUILD_IMAGES_EXTRA_PARAMETERS: [
     defaultValue: '',
     description: 'Arbitrary extra parameters to pass to the ' +
-      'build-iso command. Arguments containing spaces have to ' +
+      'build-images command. Arguments containing spaces have to ' +
       'be enclosed in double quotes, e.g. --mock-args "--with tests"'],
 ]
 

--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -151,8 +151,8 @@ def buildPackages() {
   buildStages.buildPackages(false)
 }
 
-def buildIso() {
-  buildStages.buildIso(false)
+def buildImages() {
+  buildStages.buildImages(false)
 }
 
 def uploadBuildArtifacts() {

--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -30,8 +30,8 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
           }
 
           if (currentBuild.result != 'FAILURE') {
-            stage('Build ISO') {
-              pipelineStages.buildIso()
+            stage('Build images') {
+              pipelineStages.buildImages()
             }
           }
 


### PR DESCRIPTION
This renames build-iso to build-images in all pipelines; updates
function names; and change build-images to only build installable tree
with --install-tree option.

Depends on https://github.com/open-power-host-os/builds/pull/304