### PR TITLE
Avoid conflicts when pushing changes to github.io repository

### DIFF
--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -232,6 +232,8 @@ def commitToGitRepo() {
        "HEAD:refs/heads/$params.VERSIONS_REPO_REFERENCE")
   }
   dir(GITHUB_IO_REPO_PATH) {
+    sh("git fetch $GITHUB_IO_MAIN_REPO_URL $params.GITHUB_IO_REPO_REFERENCE")
+    sh("git rebase FETCH_HEAD")
     sh("git push $GITHUB_IO_MAIN_REPO_URL " +
        "HEAD:refs/heads/$params.GITHUB_IO_REPO_REFERENCE")
   }


### PR DESCRIPTION
When devel and release pipeline are executing simultaneously, since they
reference the same branch in the github.io repository, they may fetch
that branch at the same time and get the same commit. Later, when they
try to push to this branch, the second one was failing because the tip
of the branch had been updated. Re-fetching and rebasing makes a failure
very unlikely, since those are very fast operations. Conflicts on rebase
should never happen because the pipelines create differently named
files.

The same cannot be done for the versions repository, because it would
change the commit, which was already tested. It is also unnecessary
because the pipelines reference different branches.