### PR TITLE
Stop failing the whole build when BVT fails

### DIFF
--- a/pipeline/daily/stages.groovy
+++ b/pipeline/daily/stages.groovy
@@ -260,35 +260,10 @@ def createSymlinks() {
   utils.rsyncUpload('--links latest', PERIODIC_BUILDS_DIR_RSYNC_URL)
 }
 
-def shouldNotifyOnFailure() {
-  shouldNotify = true
-
-  for (param in params) {
-    if (param.key.startsWith("SLACK") && !param.value) {
-      shouldNotify = false
-      break
-    }
-  }
-
-  return shouldNotify
+def notifyFailure() {
+  utils.notifySlack()
 }
 
-def notifyFailure() {
-  String teamDomain = params.SLACK_TEAM_DOMAIN
-  String recipient = params.SLACK_NOTIFICATION_RECIPIENT
-  String failureMsg = "${JOB_BASE_NAME} build failed. ${BUILD_URL}console"
-
-  String tokenId = utils.addSecretString(
-    params.SLACK_TOKEN, "Slack token for $recipient @ $teamDomain")
-
-  try {
-    withCredentials([string(credentialsId: tokenId, variable: 'token')]){
-      slackSend(channel: recipient, teamDomain: teamDomain, token: token,
-		color: 'danger', message: failureMsg)
-    }
-  } finally {
-    utils.removeCredentials(tokenId)
-  }
 }
 
 return this

--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -59,9 +59,7 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
         }
       }
     } catch (Exception exception) {
-      if (pipelineStages.shouldNotifyOnFailure()) {
-        pipelineStages.notifyFailure()
-      }
+      pipelineStages.notifyFailure()
       throw exception
     }
   }

--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -49,6 +49,10 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
             }
           }
 
+          if (currentBuild.result == 'UNSTABLE') {
+            pipelineStages.notifyUnstable()
+          }
+
           stage('Commit to Git repository') {
             pipelineStages.commitToGitRepo()
           }

--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -50,7 +50,9 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
           }
 
           if (currentBuild.result == 'UNSTABLE') {
-            pipelineStages.notifyUnstable()
+            stage('Notify unstable') {
+              pipelineStages.notifyUnstable()
+            }
           }
 
           stage('Commit to Git repository') {
@@ -63,7 +65,9 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
         }
       }
     } catch (Exception exception) {
-      pipelineStages.notifyFailure()
+      stage('Notify failure') {
+        pipelineStages.notifyFailure()
+      }
       throw exception
     }
   }


### PR DESCRIPTION
The Build Verification Tests are a bit unstable right now due to external factors (network issues, OS issues, etc), so let's avoid failing the whole build when BVT fails. Passing the build allows us to focus on fixing the BVT issues instead of having to scramble to make sure the build gets re-executed properly. In the case that the BVT failure is an actual one - related to the build itself -, it's still better to push some artifacts (e.g. RPMs) to the repo anyway, since debugging and fixing the issue might not be done until the next build starts.