### PR TITLE
Stop running BVT on devel pipeline

### DIFF
--- a/pipeline/devel.groovy
+++ b/pipeline/devel.groovy
@@ -43,18 +43,6 @@ def execute(Boolean skipIfNoUpdates = false, releaseCategory = 'devel') {
             pipelineStages.createReleaseNotes(releaseCategory)
           }
 
-          stage('Run BVT') {
-            node('bvt_slave_label') {
-              pipelineStages.runBVT()
-            }
-          }
-
-          if (currentBuild.result == 'UNSTABLE') {
-            stage('Notify unstable') {
-              pipelineStages.notifyUnstable()
-            }
-          }
-
           stage('Commit to Git repository') {
             pipelineStages.commitToGitRepo()
           }


### PR DESCRIPTION
There is another more complete set of tests[1] being run in HostOS so we
decided to remove this redundancy.

1- hhtps://github.com/open-power-host-os/tests