### PR TITLE
Pin release and devel pipelines to CentOS 7.5

### DIFF
--- a/pipeline/devel/parameters.groovy
+++ b/pipeline/devel/parameters.groovy
@@ -1,4 +1,10 @@
 pipelineParameters += [
+  CENTOS_ALTERNATE_MIRROR_RELEASE_URL: [
+    defaultValue: 'http://mirror.centos.org/altarch/7.5.1804',
+    description:
+      'URL up to the release component of a CentOS YUM repository ' +
+      'alternate mirror. Empty to use CentOS latest release ' +
+      'official repository.'],
   GITHUB_BOT_NAME: [
     defaultValue: constants.GITHUB_BOT_NAME,
     description:

--- a/pipeline/release/parameters.groovy
+++ b/pipeline/release/parameters.groovy
@@ -1,4 +1,10 @@
 pipelineParameters += [
+  CENTOS_ALTERNATE_MIRROR_RELEASE_URL: [
+    defaultValue: 'http://mirror.centos.org/altarch/7.5.1804',
+    description:
+      'URL up to the release component of a CentOS YUM repository ' +
+      'alternate mirror. Empty to use CentOS latest release ' +
+      'official repository.'],
   UPLOAD_SERVER_PERIODIC_BUILDS_DIR_PATH: [
     defaultValue: constants.UPLOAD_SERVER_RELEASE_DIR_PATH,
     description:


### PR DESCRIPTION
Although we intend to always use the latest version of the base
distro, it is convenient to make the transition on our own time to
avoid service interruptions. In addition we want to update the release
pipeline some time later to give us time for testing the new version.